### PR TITLE
Relax overflow detection

### DIFF
--- a/cli/asm_directive.h
+++ b/cli/asm_directive.h
@@ -93,9 +93,9 @@ public:
 
         Insn insn;
         const Error error = _assembler.encode(_scan, insn, _origin, this);
-        const bool ok = error == OK || (!_reportUndef && error == UNDEFINED_SYMBOL);
+        const bool allowUndef = !_reportUndef && error == UNDEFINED_SYMBOL;
         _scan = _assembler.errorAt();
-        if (ok) {
+        if (error == OK || allowUndef) {
             _list.operand_len = _scan - _list.operand;
             skipSpaces();
             _list.comment = _scan;
@@ -291,7 +291,7 @@ protected:
             return setError(MISSING_LABEL);
         if (_reportDuplicate && hasSymbol(label))
             return setError(DUPLICATE_LABEL);
-        Addr value;
+        uint32_t value;
         const char *scan = _parser.eval(_scan, value, this);
         const Error error = setError(_parser);
         if (!_reportUndef && error == UNDEFINED_SYMBOL) {

--- a/src/asm_operand.cpp
+++ b/src/asm_operand.cpp
@@ -19,6 +19,8 @@ const char *AsmOperand::eval(
         val16 = v.getSigned();
     } else if (v.isUnsigned() && v.getUnsigned() < 0x10000L) {
         val16 = v.getUnsigned();
+    } else if (v.isUnsigned() && (v.getSigned() < 0 && v.getSigned() >= -32768)) {
+        val16 = v.getUnsigned();
     } else {
         setError(OVERFLOW_RANGE);
     }
@@ -32,6 +34,8 @@ const char *AsmOperand::eval(
     if (v.isSigned() && v.getSigned() >= -128 && v.getSigned() < 256) {
         val8 = v.getSigned();
     } else if (v.isUnsigned() && v.getUnsigned() < 0x100) {
+        val8 = v.getUnsigned();
+    } else if (v.isUnsigned() && (v.getSigned() < 0 && v.getSigned() >= -128)) {
         val8 = v.getUnsigned();
     } else {
         setError(OVERFLOW_RANGE);

--- a/test/test_expr_cstyle.cpp
+++ b/test/test_expr_cstyle.cpp
@@ -208,6 +208,27 @@ static void test_binary_operator() {
     E32("0b0110^-1",    0xfffffff9, OK);
 }
 
+static void test_overflow() {
+    E8("0x1000-0x1080", -128, OK);
+    E8("0x1000-0x1081", 0, OVERFLOW_RANGE);
+    E8("0x10ff-0x1000", 255, OK);
+    E8("0x1100-0x1000", 0, OVERFLOW_RANGE);
+    E8("0xE000-0xE080", -128, OK);
+    E8("0xE000-0xE081", 0, OVERFLOW_RANGE);
+    E8("0xE0ff-0xE000", 255, OK);
+    E8("0xE100-0xE000", 0, OVERFLOW_RANGE);
+
+    E16("0xE000-0x6000", 0x8000, OK);
+    E16("0xE000-0x5fff", 0x8001, OK);
+    E16("0xE000-0xE001", -1,     OK);
+    E16("0x2000-0xA000", -32768, OK);
+    E16("0x2000-0xA001", 0,      OVERFLOW_RANGE);
+    E16("0x3000-0x3001", -1   ,  OK);
+
+    E16("0xE000+(-0x2000)", 0xC000, OK);
+    E16("(-0x2000)+0xE000", 0xC000, OK);
+}
+
 static void test_precedence() {
     E16("1+2-3+4",    4, OK);
     E16("1+2*3+4",   11, OK);
@@ -303,6 +324,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_bin_constant);
     RUN_TEST(test_unary_operator);
     RUN_TEST(test_binary_operator);
+    RUN_TEST(test_overflow);
     RUN_TEST(test_precedence);
     RUN_TEST(test_errors);
     return 0;

--- a/test/test_expr_intel.cpp
+++ b/test/test_expr_intel.cpp
@@ -78,7 +78,7 @@ static void test_current_address() {
     E16("$+2",      0x1002, OK);
     E16("$-2",      0x0FFE, OK);
     E16("$+0F000H", 0,       OVERFLOW_RANGE);
-    E16("$-1001H",  0,       OVERFLOW_RANGE);
+    E16("$-1001H",  0xFFFF, OK);
     E32("$+0F000H", 0x00010000, OK);
     E32("$-1001H",  0xFFFFFFFF, OK);
 

--- a/test/test_expr_moto.cpp
+++ b/test/test_expr_moto.cpp
@@ -77,7 +77,7 @@ static void test_current_address() {
     E16("*+2",     0x1002, OK);
     E16("*-2",     0x0FFE, OK);
     E16("*+$F000", 0,      OVERFLOW_RANGE);
-    E16("*-$1001", 0,      OVERFLOW_RANGE);
+    E16("*-$1001", 0xFFFF, OK);
     E32("*+$F000", 0x00010000, OK);
     E32("*-$1001", 0xFFFFFFFF, OK);
 


### PR DESCRIPTION
- Use uint32_t as symbol value even on 16 bit address machine which
  prevents undesired overflow.
- Allow a result which has value interpreted as signed is within the
  range of a result type.