### PR TITLE
Use libasm namespace

### DIFF
--- a/cli/as6502.cpp
+++ b/cli/as6502.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmM6502 assembler;
-    AsmMostekDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
+    AsmMostekDirective<Config> directive(assembler);
+    AsmDriver<Config, SRecord<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as6502.cpp
+++ b/cli/as6502.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmM6502 assembler;
-    AsmMostekDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, SRecord<target::uintptr_t>> driver(directive);
+    AsmMostekDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as6800.cpp
+++ b/cli/as6800.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc6800 assembler;
-    AsmMotoDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config> directive(assembler);
+    AsmDriver<Config, SRecord<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as6800.cpp
+++ b/cli/as6800.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc6800 assembler;
-    AsmMotoDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, SRecord<target::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as68000.cpp
+++ b/cli/as68000.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc68000 assembler;
-    AsmMotoDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, SRecord<target::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as68000.cpp
+++ b/cli/as68000.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc68000 assembler;
-    AsmMotoDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config> directive(assembler);
+    AsmDriver<Config, SRecord<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as6809.cpp
+++ b/cli/as6809.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc6809 assembler;
-    AsmMotoDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, SRecord<target::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as6809.cpp
+++ b/cli/as6809.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmMc6809 assembler;
-    AsmMotoDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, SRecord<Config::uintptr_t>> driver(directive);
+    AsmMotoDirective<Config> directive(assembler);
+    AsmDriver<Config, SRecord<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as8080.cpp
+++ b/cli/as8080.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmI8080 assembler;
-    AsmIntelDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, IntelHex<target::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as8080.cpp
+++ b/cli/as8080.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmI8080 assembler;
-    AsmIntelDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config> directive(assembler);
+    AsmDriver<Config, IntelHex<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as9900.cpp
+++ b/cli/as9900.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmTms9900 assembler;
-    AsmIntelDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config> directive(assembler);
+    AsmDriver<Config, IntelHex<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/as9900.cpp
+++ b/cli/as9900.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmTms9900 assembler;
-    AsmIntelDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, IntelHex<target::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/asm_directive.h
+++ b/cli/asm_directive.h
@@ -116,7 +116,7 @@ public:
             return setError(OK); // skip comment
         }
 
-        Insn insn;
+        Insn<Addr> insn;
         const Error error = _assembler.encode(_scan, insn, _origin, this);
         const bool allowUndef = !_reportUndef && error == UNDEFINED_SYMBOL;
         _scan = _assembler.errorAt();

--- a/cli/asm_directive.h
+++ b/cli/asm_directive.h
@@ -30,10 +30,12 @@
 namespace libasm {
 namespace cli {
 
-template <typename Addr>
+template <typename Conf>
 class AsmDirective : public ErrorReporter,
-                     public AsmLine<Addr>,
+                     public AsmLine<typename Conf::uintptr_t>,
                      protected SymbolTable {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
     virtual ~AsmDirective() {
         free(_line);
@@ -46,7 +48,7 @@ public:
         return _assembler.listCpu();
     }
 
-    Error assembleLine(const char *line, CliMemory<Addr> &memory) {
+    Error assembleLine(const char *line, CliMemory<Conf> &memory) {
         _scan = line;
         if (_scan == nullptr) {
             return OK;
@@ -85,7 +87,7 @@ public:
             _scan = end;
             skipSpaces();
             _list.operand = _scan;
-            const Addr origin = _origin;
+            const addr_t origin = _origin;
             const Error error = processPseudo(directive.c_str(), label, memory);
             if (error == UNKNOWN_DIRECTIVE) {
                 _scan = _list.instruction;
@@ -116,7 +118,7 @@ public:
             return setError(OK); // skip comment
         }
 
-        Insn<Addr> insn;
+        Insn<Conf> insn;
         const Error error = _assembler.encode(_scan, insn, _origin, this);
         const bool allowUndef = !_reportUndef && error == UNDEFINED_SYMBOL;
         _scan = _assembler.errorAt();
@@ -135,7 +137,7 @@ public:
         return setError(error);
     }
 
-    void setOrigin(Addr origin) { _origin = origin; }
+    void setOrigin(addr_t origin) { _origin = origin; }
     const char *errorAt() const { return _scan; }
     void setSymbolMode(bool reportUndef, bool reportDuplicate) {
         _reportUndef = reportUndef;
@@ -185,7 +187,7 @@ public:
     // AsmLine
     uint16_t lineNumber() const override { return _list.line_number; }
     uint16_t includeNest() const override { return _list.include_nest; }
-    Addr startAddress() const override { return _list.address; }
+    addr_t startAddress() const override { return _list.address; }
     int generatedSize() const override { return _list.length; }
     uint8_t getByte(int offset) const override {
         uint8_t val = 0;
@@ -218,7 +220,7 @@ public:
     // Error reporting
 
 protected:
-    AsmDirective(Assembler<Addr> &assembler)
+    AsmDirective(Assembler<Conf> &assembler)
         : _assembler(assembler),
           _parser(assembler.getParser()),
           _line_len(128),
@@ -252,12 +254,12 @@ protected:
         const Source *include_from;
     };
 
-    Assembler<Addr> &_assembler;
+    Assembler<Conf> &_assembler;
     AsmOperand &_parser;
     size_t _line_len;
     char *_line;
     const char *_scan;
-    Addr _origin;
+    addr_t _origin;
     bool _reportUndef;
     bool _reportDuplicate;
     int _labelWidth;
@@ -270,8 +272,8 @@ protected:
         uint16_t include_nest;
         const char *label;      // if label defined
         int label_len;
-        Addr address;
-        CliMemory<Addr> *memory;
+        addr_t address;
+        CliMemory<Conf> *memory;
         int length;
         bool value_defined;
         uint32_t value;
@@ -290,12 +292,12 @@ protected:
     }
 
     virtual Error processDirective(
-        const char *directive, const char *&label, CliMemory<Addr> &memory) {
+        const char *directive, const char *&label, CliMemory<Conf> &memory) {
         return UNKNOWN_DIRECTIVE;
     }
 
     Error processPseudo(
-        const char *directive, const char *&label, CliMemory<Addr> &memory) {
+        const char *directive, const char *&label, CliMemory<Conf> &memory) {
         if (processDirective(directive, label, memory) != UNKNOWN_DIRECTIVE)
             return getError();
         if (strcasecmp(directive, "org") == 0)
@@ -321,7 +323,7 @@ protected:
     }
 
     Error defineOrigin() {
-        Addr value;
+        addr_t value;
         const char *scan = _parser.eval(_scan, value, this);
         if (_parser.getError())
             return setError(_parser);
@@ -332,7 +334,7 @@ protected:
         return setError(OK);
     }
 
-    Error defineLabel(const char *&label, CliMemory<Addr> &memory) {
+    Error defineLabel(const char *&label, CliMemory<Conf> &memory) {
         if (label == nullptr)
             return setError(MISSING_LABEL);
         if (_reportDuplicate && hasSymbol(label))
@@ -366,7 +368,7 @@ protected:
         return openSource(filename, end);
     }
 
-    Error defineBytes(CliMemory<Addr> &memory) {
+    Error defineBytes(CliMemory<Conf> &memory) {
         _list.address = _origin;
         _list.length = 0;
         do {
@@ -408,7 +410,7 @@ protected:
         return setError(OK);
     }
 
-    Error defineWords(CliMemory<Addr> &memory) {
+    Error defineWords(CliMemory<Conf> &memory) {
         _list.address = _origin;
         _list.length = 0;
         do {
@@ -509,16 +511,16 @@ private:
     }
 };
 
-template<typename Addr>
-class AsmMotoDirective : public AsmDirective<Addr> {
+template<typename Conf>
+class AsmMotoDirective : public AsmDirective<Conf> {
 public:
-    AsmMotoDirective(Assembler<Addr> &assembler)
-        : AsmDirective<Addr>(assembler) {}
+    AsmMotoDirective(Assembler<Conf> &assembler)
+        : AsmDirective<Conf>(assembler) {}
 
 protected:
     Error processDirective(
         const char *directive, const char *&label,
-        CliMemory<Addr> &memory) override {
+        CliMemory<Conf> &memory) override {
         if (strcasecmp(directive, "fcb") == 0 ||
             strcasecmp(directive, "fcc") == 0)
             return this->defineBytes(memory);
@@ -530,16 +532,16 @@ protected:
     }
 };
 
-template<typename Addr>
-class AsmMostekDirective : public AsmDirective<Addr> {
+template<typename Conf>
+class AsmMostekDirective : public AsmDirective<Conf> {
 public:
-    AsmMostekDirective(Assembler<Addr> &assembler)
-        : AsmDirective<Addr>(assembler) {}
+    AsmMostekDirective(Assembler<Conf> &assembler)
+        : AsmDirective<Conf>(assembler) {}
 
 protected:
     Error processDirective(
         const char *directive, const char *&label,
-        CliMemory<Addr> &memory) override {
+        CliMemory<Conf> &memory) override {
         if (strcmp(directive, ":=") == 0
             || strcmp(directive, "=") == 0) {
             return this->defineLabel(label, memory);
@@ -554,16 +556,16 @@ protected:
     }
 };
 
-template<typename Addr>
-class AsmIntelDirective : public AsmDirective<Addr> {
+template<typename Conf>
+class AsmIntelDirective : public AsmDirective<Conf> {
 public:
-    AsmIntelDirective(Assembler<Addr> &assembler)
-        : AsmDirective<Addr>(assembler) {}
+    AsmIntelDirective(Assembler<Conf> &assembler)
+        : AsmDirective<Conf>(assembler) {}
 
 protected:
     Error processDirective(
         const char *directive, const char *&label,
-        CliMemory<Addr> &memory) override {
+        CliMemory<Conf> &memory) override {
         this->_parser.isSymbolLetter(0);
         if (strcasecmp(directive, "db") == 0)
             return this->defineBytes(memory);

--- a/cli/asm_driver.h
+++ b/cli/asm_driver.h
@@ -26,7 +26,7 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr, typename Formatter>
+template<typename Addr, typename InsnUnit, typename Formatter>
 class AsmDriver {
 public:
     AsmDriver(AsmDirective<Addr> &directive)
@@ -133,7 +133,7 @@ private:
 
     void printListing(CliMemory<Addr> &memory, FILE *out) {
         _listing.reset(
-            _directive, sizeof(target::opcode_t), _uppercase, _line_number);
+            _directive, sizeof(InsnUnit), _uppercase, _line_number);
         do {
             fprintf(out, "%s\n", _listing.getLine());
         } while (_listing.hasNext());

--- a/cli/asm_listing.h
+++ b/cli/asm_listing.h
@@ -46,16 +46,16 @@ public:
     virtual int operandWidth() const = 0;
 };
 
-template<typename Address>
+template<typename Conf>
 class AsmListing {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
     void reset(
-        AsmLine<Address> &line,
-        size_t insnUnitSize,
+        AsmLine<addr_t> &line,
         bool uppercase,
         bool lineNumner) {
         _line = &line;
-        _insnUnitSize = insnUnitSize;
         _uppercase = uppercase;
         _lineNumber = lineNumner;
         _next = 0;
@@ -79,8 +79,7 @@ public:
     }
 
 private:
-    const AsmLine<Address> *_line;
-    size_t _insnUnitSize;
+    const AsmLine<addr_t> *_line;
     bool _uppercase = false;
     bool _lineNumber = false;
     int _next;
@@ -129,8 +128,8 @@ private:
         formatUint16(static_cast<uint16_t>(val), fixedWidth, zeroSuppress);
     }
     void formatAddress(
-        Address addr, bool fixedWidth = true, bool zeroSuppress = false) {
-        if (sizeof(Address) == 2) {
+        addr_t addr, bool fixedWidth = true, bool zeroSuppress = false) {
+        if (sizeof(addr_t) == 2) {
             formatUint16(addr, fixedWidth, zeroSuppress);
         } else {
             formatUint32(addr, fixedWidth, zeroSuppress);
@@ -142,7 +141,7 @@ private:
         int i = 0;
         while (base + i < _line->generatedSize() && i < maxBytes) {
             uint8_t val = _line->getByte(base + i);
-            if (_insnUnitSize == 1 || (i % 2) == 0)
+            if (sizeof(typename Conf::opcode_t) == 1 || (i % 2) == 0)
                 _out += ' ';
             formatUint8(val);
             i++;
@@ -205,7 +204,7 @@ private:
         } else {
             formattedBytes = formatBytes(_next);
         }
-        const int dataTextLen = _insnUnitSize == 2
+        const int dataTextLen = sizeof(typename Conf::opcode_t) == 2
             ? (_line->maxBytes() / 2) * 5
             : (_line->maxBytes() * 3);
         if (_next == 0) formatContent(pos + dataTextLen + 1);

--- a/cli/asz80.cpp
+++ b/cli/asz80.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmZ80 assembler;
-    AsmIntelDirective<Config::uintptr_t> directive(assembler);
-    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config> directive(assembler);
+    AsmDriver<Config, IntelHex<Config>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/asz80.cpp
+++ b/cli/asz80.cpp
@@ -24,8 +24,8 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     AsmZ80 assembler;
-    AsmIntelDirective<target::uintptr_t> directive(assembler);
-    AsmDriver<target::uintptr_t, IntelHex<target::uintptr_t>> driver(directive);
+    AsmIntelDirective<Config::uintptr_t> directive(assembler);
+    AsmDriver<Config::uintptr_t, Config::opcode_t, IntelHex<Config::uintptr_t>> driver(directive);
     return driver.main(argc, argv);
 }
 

--- a/cli/cli_memory.h
+++ b/cli/cli_memory.h
@@ -29,20 +29,22 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr>
-class CliMemory : public DisMemory<Addr> {
+template<typename Conf>
+class CliMemory : public DisMemory<Conf> {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
-    CliMemory() : DisMemory<Addr>(0) {
+    CliMemory() : DisMemory<Conf>(0) {
         invalidateWriteCache();
         invalidateReadCache();
     }
 
-    void setAddress(Addr addr) {
+    void setAddress(addr_t addr) {
         this->_address = addr;
     }
 
     bool hasNext() const override {
-        Addr addr = this->_address;
+        addr_t addr = this->_address;
         if (insideOf(_read_cache, addr)) return true;
         for (auto segment = _segments.cbegin();
              segment != _segments.cend();
@@ -64,12 +66,12 @@ protected:
     }
 
 public:
-    void writeBytes(Addr addr, const uint8_t *p, size_t size) {
+    void writeBytes(addr_t addr, const uint8_t *p, size_t size) {
         for (const uint8_t *end = p + size; p < end; p++)
             writeByte(addr++, *p);
     }
 
-    bool readBytes(Addr addr, uint8_t *p, size_t size) const {
+    bool readBytes(addr_t addr, uint8_t *p, size_t size) const {
         for (uint8_t *end = p + size; p < end; p++) {
             if (!readByte(addr, p))
                 return false;
@@ -77,7 +79,7 @@ public:
         return true;
     }
 
-    void writeByte(Addr addr, uint8_t val) {
+    void writeByte(addr_t addr, uint8_t val) {
         // Shortcut for most possible case, appending byte to cached segment.
         if (atEndOf(_write_cache, addr)) {
             appendTo(_write_cache, addr, val);
@@ -106,7 +108,7 @@ public:
         createSegment(addr, val);
     }
 
-    bool readByte(Addr addr, uint8_t &val) const {
+    bool readByte(addr_t addr, uint8_t &val) const {
         if (insideOf(_read_cache, addr)) {
             val = readFrom(_read_cache, addr);
             return true;
@@ -124,7 +126,7 @@ public:
         return false;
     }
 
-    bool equals(const CliMemory<Addr> &other) const {
+    bool equals(const CliMemory<Conf> &other) const {
         auto a = _segments.cbegin();
         auto b = other._segments.cbegin();
         while (a != _segments.cend() && b != other._segments.cend()) {
@@ -160,7 +162,7 @@ public:
 
 private:
     // Memory segment list in ascending order of start address.
-    typedef std::map<Addr, std::vector<uint8_t>> Segments;
+    typedef std::map<addr_t, std::vector<uint8_t>> Segments;
     typedef typename Segments::iterator Segment;
     typedef typename Segments::const_iterator ConstSegment;
     Segments _segments;
@@ -175,40 +177,40 @@ private:
         _read_cache = _segments.cend();
     }
 
-    bool insideOf(ConstSegment &segment, Addr addr) const {
+    bool insideOf(ConstSegment &segment, addr_t addr) const {
         return segment != _segments.cend()
             && addr >= segment->first
             && addr < segment->first + segment->second.size();
     }
 
-    bool insideOf(Segment segment, Addr addr) const {
+    bool insideOf(Segment segment, addr_t addr) const {
         return segment != _segments.end()
             && addr >= segment->first
             && addr < segment->first + segment->second.size();
     }
 
-    bool atEndOf(Segment segment, Addr addr) const {
+    bool atEndOf(Segment segment, addr_t addr) const {
         return segment != _segments.end()
             && addr == segment->first + segment->second.size();
     }
 
-    uint8_t readFrom(ConstSegment &segment, Addr addr) const {
+    uint8_t readFrom(ConstSegment &segment, addr_t addr) const {
         return segment->second.at(addr - segment->first);
     }
 
-    void appendTo(Segment &segment, Addr addr, uint8_t val) {
+    void appendTo(Segment &segment, addr_t addr, uint8_t val) {
         segment->second.push_back(val);
         _write_cache = segment;
         aggregate(segment);
     }
 
-    void replaceAt(Segment &segment, Addr addr, uint8_t val) {
+    void replaceAt(Segment &segment, addr_t addr, uint8_t val) {
         segment->second.at(addr - segment->first) = val;
         _write_cache = segment;
         aggregate(segment);
     }
 
-    void createSegment(Addr addr, uint8_t val) {
+    void createSegment(addr_t addr, uint8_t val) {
         _write_cache = _segments.insert(
             std::make_pair(addr, std::vector<uint8_t>())).first;
         _write_cache->second.push_back(val);

--- a/cli/dis6502.cpp
+++ b/cli/dis6502.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisM6502 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis6502.cpp
+++ b/cli/dis6502.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisM6502 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis6800.cpp
+++ b/cli/dis6800.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc6800 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis6800.cpp
+++ b/cli/dis6800.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc6800 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis68000.cpp
+++ b/cli/dis68000.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc68000 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis68000.cpp
+++ b/cli/dis68000.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc68000 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis6809.cpp
+++ b/cli/dis6809.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc6809 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis6809.cpp
+++ b/cli/dis6809.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisMc6809 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis8080.cpp
+++ b/cli/dis8080.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisI8080 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis8080.cpp
+++ b/cli/dis8080.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisI8080 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis9900.cpp
+++ b/cli/dis9900.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisTms9900 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis9900.cpp
+++ b/cli/dis9900.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisTms9900 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/dis_driver.h
+++ b/cli/dis_driver.h
@@ -29,10 +29,12 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr, typename InsnUnit>
+template<typename Conf>
 class DisDriver {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
-    DisDriver(Disassembler<Addr> &disassembler)
+    DisDriver(Disassembler<Conf> &disassembler)
         : _disassembler(disassembler),
           _uppercase(false)
     {}
@@ -51,7 +53,7 @@ public:
             fprintf(stderr, "Can't open input file %s\n", _input_name);
             return 1;
         }
-        CliMemory<Addr> memory;
+        CliMemory<Conf> memory;
         if (readInput(input, _input_name, memory) != 0)
             return 1;
         fclose(input);
@@ -74,8 +76,8 @@ public:
         }
         memory.dump(
             [this, output, list, &memory]
-            (Addr base, const uint8_t *data, size_t size) {
-                DisListing<Addr, InsnUnit> listing(_disassembler, memory, _uppercase);
+            (addr_t base, const uint8_t *data, size_t size) {
+                DisListing<Conf> listing(_disassembler, memory, _uppercase);
                 if (list) {
                     fprintf(list, "%s\n", listing.origin(base, true));
                     fflush(list);
@@ -84,9 +86,9 @@ public:
                     fprintf(output, "%s\n", listing.origin(base));
                     fflush(output);
                 }
-                Insn<Addr> insn;
+                Insn<Conf> insn;
                 for (size_t pc = 0; pc < size; pc += insn.length()) {
-                    Addr address = base + pc;
+                    addr_t address = base + pc;
                     listing.disassemble(address, insn);
                     if (list) {
                         if (_disassembler.getError())
@@ -113,16 +115,16 @@ public:
     }
 
 private:
-    Disassembler<Addr> &_disassembler;
+    Disassembler<Conf> &_disassembler;
     bool _uppercase;
     const char *_progname;
     const char *_input_name;
     const char *_output_name;
     const char *_list_name;
-    BinFormatter<Addr> *_formatter;
+    BinFormatter<Conf> *_formatter;
 
     int readInput(
-        FILE *input, const char *filename, CliMemory<Addr> &memory) {
+        FILE *input, const char *filename, CliMemory<Conf> &memory) {
         int lineno = 0;
         int errors = 0;
         size_t line_len = 128;
@@ -130,7 +132,7 @@ private:
         int len;
         while ((len = getLine(line, line_len, input)) > 0) {
             lineno++;
-            Addr addr;
+            addr_t addr;
             size_t size;
             uint8_t *data = _formatter->decode(line, addr, size);
             if (data == nullptr) {
@@ -151,7 +153,7 @@ private:
         return errors;
     }
 
-    BinFormatter<Addr> *determineInputFormat(const char *input_name) {
+    BinFormatter<Conf> *determineInputFormat(const char *input_name) {
         FILE *input = fopen(input_name, "r");
         if (input == nullptr) {
             fprintf(stderr, "Can't open input file %s\n", input_name);
@@ -165,8 +167,8 @@ private:
         const char c = (len > 0) ? *line : 0;
         free(line);
 
-        if (c == 'S') return new SRecord<Addr>();
-        if (c == ':') return new IntelHex<Addr>();
+        if (c == 'S') return new SRecord<Conf>();
+        if (c == ':') return new IntelHex<Conf>();
         return nullptr;
     }
     

--- a/cli/dis_driver.h
+++ b/cli/dis_driver.h
@@ -29,7 +29,7 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr>
+template<typename Addr, typename InsnUnit>
 class DisDriver {
 public:
     DisDriver(Disassembler<Addr> &disassembler)
@@ -75,7 +75,7 @@ public:
         memory.dump(
             [this, output, list, &memory]
             (Addr base, const uint8_t *data, size_t size) {
-                DisListing<Addr> listing(_disassembler, memory, _uppercase);
+                DisListing<Addr, InsnUnit> listing(_disassembler, memory, _uppercase);
                 if (list) {
                     fprintf(list, "%s\n", listing.origin(base, true));
                     fflush(list);
@@ -84,7 +84,7 @@ public:
                     fprintf(output, "%s\n", listing.origin(base));
                     fflush(output);
                 }
-                Insn insn;
+                Insn<Addr> insn;
                 for (size_t pc = 0; pc < size; pc += insn.length()) {
                     Addr address = base + pc;
                     listing.disassemble(address, insn);

--- a/cli/dis_listing.h
+++ b/cli/dis_listing.h
@@ -24,7 +24,7 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr>
+template<typename Addr, typename InsnUnit>
 class DisListing : public AsmLine<Addr> {
 public:
     DisListing(
@@ -39,11 +39,11 @@ public:
           _operandWidth(8)
     {}
 
-    Error disassemble(Addr addr, Insn &insn) {
+    Error disassemble(Addr addr, Insn<Addr> &insn) {
         _memory.setAddress(addr);
         const Error error = _disassembler.decode(
             _memory, insn, _operands, nullptr, _uppercase);
-        _listing.reset(*this, sizeof(target::opcode_t), _uppercase, false);
+        _listing.reset(*this, sizeof(InsnUnit), _uppercase, false);
         _address = addr;
         _generated_size = insn.length();
         _instruction = insn.name();
@@ -53,7 +53,7 @@ public:
     const char *origin(Addr origin, bool withBytes = false) {
         _disassembler.getFormatter().output(
             _operands, origin, 16, false, sizeof(Addr));
-        _listing.reset(*this, sizeof(target::opcode_t), _uppercase, false);
+        _listing.reset(*this, sizeof(InsnUnit), _uppercase, false);
         _address = origin;
         _generated_size = 0;
         _instruction = _uppercase ? "ORG" : "org";

--- a/cli/dis_listing.h
+++ b/cli/dis_listing.h
@@ -24,12 +24,14 @@
 namespace libasm {
 namespace cli {
 
-template<typename Addr, typename InsnUnit>
-class DisListing : public AsmLine<Addr> {
+template<typename Conf>
+class DisListing : public AsmLine<typename Conf::uintptr_t> {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
     DisListing(
-        Disassembler<Addr>&disassembler,
-        CliMemory<Addr> &memory,
+        Disassembler<Conf>&disassembler,
+        CliMemory<Conf> &memory,
         bool uppercase = false)
         : _disassembler(disassembler),
           _memory(memory),
@@ -39,21 +41,21 @@ public:
           _operandWidth(8)
     {}
 
-    Error disassemble(Addr addr, Insn<Addr> &insn) {
+    Error disassemble(addr_t addr, Insn<Conf> &insn) {
         _memory.setAddress(addr);
         const Error error = _disassembler.decode(
             _memory, insn, _operands, nullptr, _uppercase);
-        _listing.reset(*this, sizeof(InsnUnit), _uppercase, false);
+        _listing.reset(*this, _uppercase, false);
         _address = addr;
         _generated_size = insn.length();
         _instruction = insn.name();
         return error;
     }
 
-    const char *origin(Addr origin, bool withBytes = false) {
+    const char *origin(addr_t origin, bool withBytes = false) {
         _disassembler.getFormatter().output(
-            _operands, origin, 16, false, sizeof(Addr));
-        _listing.reset(*this, sizeof(InsnUnit), _uppercase, false);
+            _operands, origin, 16, false, sizeof(addr_t));
+        _listing.reset(*this, _uppercase, false);
         _address = origin;
         _generated_size = 0;
         _instruction = _uppercase ? "ORG" : "org";
@@ -65,13 +67,13 @@ public:
     const char *getContent() { return _listing.getContent(); }
 
 private:
-    Disassembler<Addr> &_disassembler;
-    CliMemory<Addr> &_memory;
-    AsmListing<Addr> _listing;
+    Disassembler<Conf> &_disassembler;
+    CliMemory<Conf> &_memory;
+    AsmListing<Conf> _listing;
     bool _uppercase;
     int _labelWidth;
     int _operandWidth;
-    Addr _address;
+    addr_t _address;
     int _generated_size;
     const char *_instruction;
     char _operands[40];
@@ -79,7 +81,7 @@ private:
     // AsmLine<Addr>
     uint16_t lineNumber() const override { return 0; }
     uint16_t includeNest() const override { return 0; }
-    Addr startAddress() const override { return _address; }
+    addr_t startAddress() const override { return _address; }
     int generatedSize() const override { return _generated_size; }
     uint8_t getByte(int offset) const override {
         uint8_t val = 0;
@@ -102,7 +104,7 @@ private:
     std::string getComment() const override { return ""; }
     int maxBytes() const override { return 6; }
     int labelWidth() const override { return _labelWidth; }
-    int instructionWidth() const override { return _disassembler.maxName() + 1; }
+    int instructionWidth() const override { return Conf::name_max + 1; }
     int operandWidth() const override { return _operandWidth; }
 };
 

--- a/cli/disz80.cpp
+++ b/cli/disz80.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisZ80 disassembler;
-    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
+    DisDriver<Config> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/cli/disz80.cpp
+++ b/cli/disz80.cpp
@@ -22,7 +22,7 @@ using namespace libasm::cli;
 
 int main(int argc, const char **argv) {
     DisZ80 disassembler;
-    DisDriver<target::uintptr_t> driver(disassembler);
+    DisDriver<Config::uintptr_t, Config::opcode_t> driver(disassembler);
     return driver.main(argc, argv);
 }
 

--- a/examples/asm_mc68000/asm_mc68000.ino
+++ b/examples/asm_mc68000/asm_mc68000.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::mc68000;
 
 AsmMc68000 as68k;
-Assembler<Config::uintptr_t> &assembler(as68k);
+Assembler<Config> &assembler(as68k);
 
 void assemble(const char *line) {
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   if (assembler.encode(line, insn, 0x10000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/asm_mc68000/asm_mc68000.ino
+++ b/examples/asm_mc68000/asm_mc68000.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::mc68000;
 
 AsmMc68000 as68k;
-Assembler<target::uintptr_t> &assembler(as68k);
+Assembler<Config::uintptr_t> &assembler(as68k);
 
 void assemble(const char *line) {
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   if (assembler.encode(line, insn, 0x10000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/asm_mc6809/asm_mc6809.ino
+++ b/examples/asm_mc6809/asm_mc6809.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::mc6809;
 
 AsmMc6809 as6809;
-Assembler<Config::uintptr_t> &assembler(as6809);
+Assembler<Config> &assembler(as6809);
 
 void assemble(const char *line) {
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   if (assembler.encode(line, insn, 0x1000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/asm_mc6809/asm_mc6809.ino
+++ b/examples/asm_mc6809/asm_mc6809.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::mc6809;
 
 AsmMc6809 as6809;
-Assembler<target::uintptr_t> &assembler(as6809);
+Assembler<Config::uintptr_t> &assembler(as6809);
 
 void assemble(const char *line) {
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   if (assembler.encode(line, insn, 0x1000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/asm_z80/asm_z80.ino
+++ b/examples/asm_z80/asm_z80.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::z80;
 
 AsmZ80 asz80;
-Assembler<target::uintptr_t> &assembler(asz80);
+Assembler<Config::uintptr_t> &assembler(asz80);
 
 void assemble(const char *line) {
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   if (assembler.encode(line, insn, 0x1000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/asm_z80/asm_z80.ino
+++ b/examples/asm_z80/asm_z80.ino
@@ -21,10 +21,10 @@ using namespace libasm;
 using namespace libasm::z80;
 
 AsmZ80 asz80;
-Assembler<Config::uintptr_t> &assembler(asz80);
+Assembler<Config> &assembler(asz80);
 
 void assemble(const char *line) {
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   if (assembler.encode(line, insn, 0x1000, nullptr)) {
     Cli.print(F("Error "));
     Cli.print(assembler.getError());

--- a/examples/dis_mc68000/dis_mc68000.ino
+++ b/examples/dis_mc68000/dis_mc68000.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::mc68000;
 
 DisMc68000 dis68k;
-Disassembler<uint32_t> &disassembler(dis68k);
+Disassembler<Config::uintptr_t> &disassembler(dis68k);
 
-void disassemble(DisMemory<uint32_t> &memory) {
+void disassemble(DisMemory<Config::uintptr_t> &memory) {
   char operands[20];
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -52,7 +52,7 @@ void disassemble(DisMemory<uint32_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<uint32_t> memory(0x10000, line);
+  StrMemory<Config::uintptr_t> memory(0x10000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_mc68000/dis_mc68000.ino
+++ b/examples/dis_mc68000/dis_mc68000.ino
@@ -22,9 +22,9 @@ using namespace libasm;
 using namespace libasm::mc68000;
 
 DisMc68000 dis68k;
-Disassembler<target::uintptr_t> &disassembler(dis68k);
+Disassembler<uint32_t> &disassembler(dis68k);
 
-void disassemble(DisMemory<target::uintptr_t> &memory) {
+void disassemble(DisMemory<uint32_t> &memory) {
   char operands[20];
   Insn insn;
   while (memory.hasNext()) {
@@ -52,7 +52,7 @@ void disassemble(DisMemory<target::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory memory(0x10000, line);
+  StrMemory<uint32_t> memory(0x10000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_mc68000/dis_mc68000.ino
+++ b/examples/dis_mc68000/dis_mc68000.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::mc68000;
 
 DisMc68000 dis68k;
-Disassembler<Config::uintptr_t> &disassembler(dis68k);
+Disassembler<Config> &disassembler(dis68k);
 
-void disassemble(DisMemory<Config::uintptr_t> &memory) {
+void disassemble(DisMemory<Config> &memory) {
   char operands[20];
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -40,11 +40,10 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
         val |= insn.bytes()[i+1];
         Cli.printUint16(val);
       }
-      for (int i = insn.length(); i < disassembler.maxBytes(); i += 2)
+      for (int i = insn.length(); i < Config::code_max; i += 2)
         Cli.print(F("     "));
       Cli.print(' ');
-      for (size_t n = Cli.print(insn.name());
-           n <= disassembler.maxName(); n++)
+      for (size_t n = Cli.print(insn.name()); n <= Config::name_max; n++)
         Cli.print(' ');
       Cli.println(operands);
     }
@@ -52,7 +51,7 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<Config::uintptr_t> memory(0x10000, line);
+  StrMemory<Config> memory(0x10000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_mc6809/dis_mc6809.ino
+++ b/examples/dis_mc6809/dis_mc6809.ino
@@ -22,9 +22,9 @@ using namespace libasm;
 using namespace libasm::mc6809;
 
 DisMc6809 dis6809;
-Disassembler<target::uintptr_t> &disassembler(dis6809);
+Disassembler<uint16_t> &disassembler(dis6809);
 
-void disassemble(DisMemory<target::uintptr_t> &memory) {
+void disassemble(DisMemory<uint16_t> &memory) {
   char operands[20];
   Insn insn;
   while (memory.hasNext()) {
@@ -51,7 +51,7 @@ void disassemble(DisMemory<target::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory memory(0x1000, line);
+  StrMemory<uint16_t> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_mc6809/dis_mc6809.ino
+++ b/examples/dis_mc6809/dis_mc6809.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::mc6809;
 
 DisMc6809 dis6809;
-Disassembler<uint16_t> &disassembler(dis6809);
+Disassembler<Config::uintptr_t> &disassembler(dis6809);
 
-void disassemble(DisMemory<uint16_t> &memory) {
+void disassemble(DisMemory<Config::uintptr_t> &memory) {
   char operands[20];
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -51,7 +51,7 @@ void disassemble(DisMemory<uint16_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<uint16_t> memory(0x1000, line);
+  StrMemory<Config::uintptr_t> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_mc6809/dis_mc6809.ino
+++ b/examples/dis_mc6809/dis_mc6809.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::mc6809;
 
 DisMc6809 dis6809;
-Disassembler<Config::uintptr_t> &disassembler(dis6809);
+Disassembler<Config> &disassembler(dis6809);
 
-void disassemble(DisMemory<Config::uintptr_t> &memory) {
+void disassemble(DisMemory<Config> &memory) {
   char operands[20];
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -39,11 +39,10 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
         uint8_t val = insn.bytes()[i];
         Cli.printUint8(val);
       }
-      for (int i = insn.length(); i < disassembler.maxBytes(); i++)
+      for (int i = insn.length(); i < Config::code_max; i++)
         Cli.print(F("   "));
       Cli.print(' ');
-      for (size_t n = Cli.print(insn.name());
-           n <= disassembler.maxName(); n++)
+      for (size_t n = Cli.print(insn.name()); n <= Config::name_max; n++)
         Cli.print(' ');
       Cli.println(operands);
     }
@@ -51,7 +50,7 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<Config::uintptr_t> memory(0x1000, line);
+  StrMemory<Config> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_z80/dis_z80.ino
+++ b/examples/dis_z80/dis_z80.ino
@@ -22,9 +22,9 @@ using namespace libasm;
 using namespace libasm::z80;
 
 DisZ80 disz80;
-Disassembler<target::uintptr_t> &disassembler(disz80);
+Disassembler<uint16_t> &disassembler(disz80);
 
-void disassemble(DisMemory<target::uintptr_t> &memory) {
+void disassemble(DisMemory<uint16_t> &memory) {
   char operands[20];
   Insn insn;
   while (memory.hasNext()) {
@@ -51,7 +51,7 @@ void disassemble(DisMemory<target::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory memory(0x1000, line);
+  StrMemory<uint16_t> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_z80/dis_z80.ino
+++ b/examples/dis_z80/dis_z80.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::z80;
 
 DisZ80 disz80;
-Disassembler<uint16_t> &disassembler(disz80);
+Disassembler<Config::uintptr_t> &disassembler(disz80);
 
-void disassemble(DisMemory<uint16_t> &memory) {
+void disassemble(DisMemory<Config::uintptr_t> &memory) {
   char operands[20];
-  Insn insn;
+  Insn<Config::uintptr_t> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -51,7 +51,7 @@ void disassemble(DisMemory<uint16_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<uint16_t> memory(0x1000, line);
+  StrMemory<Config::uintptr_t> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/examples/dis_z80/dis_z80.ino
+++ b/examples/dis_z80/dis_z80.ino
@@ -22,11 +22,11 @@ using namespace libasm;
 using namespace libasm::z80;
 
 DisZ80 disz80;
-Disassembler<Config::uintptr_t> &disassembler(disz80);
+Disassembler<Config> &disassembler(disz80);
 
-void disassemble(DisMemory<Config::uintptr_t> &memory) {
+void disassemble(DisMemory<Config> &memory) {
   char operands[20];
-  Insn<Config::uintptr_t> insn;
+  Insn<Config> insn;
   while (memory.hasNext()) {
     if (disassembler.decode(memory, insn, operands, nullptr)) {
       Cli.print(F("Error "));
@@ -39,11 +39,10 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
         uint8_t val = insn.bytes()[i];
         Cli.printUint8(val);
       }
-      for (int i = insn.length(); i < disassembler.maxBytes(); i++)
+      for (int i = insn.length(); i < Config::code_max; i++)
         Cli.print(F("   "));
       Cli.print(' ');
-      for (size_t n = Cli.print(insn.name());
-           n <= disassembler.maxName(); n++)
+      for (size_t n = Cli.print(insn.name()); n <= Config::name_max; n++)
         Cli.print(' ');
       Cli.println(operands);
     }
@@ -51,7 +50,7 @@ void disassemble(DisMemory<Config::uintptr_t> &memory) {
 }
 
 bool handleLine(Cli::State state, char *line, uintptr_t extra) {
-  StrMemory<Config::uintptr_t> memory(0x1000, line);
+  StrMemory<Config> memory(0x1000, line);
   disassemble(memory);
   return Cli.readLine(handleLine, 0);
 }

--- a/src/asm_i8080.cpp
+++ b/src/asm_i8080.cpp
@@ -112,7 +112,7 @@ Error AsmI8080::encodeIoaddr(InsnI8080 &insn) {
     return checkLineEnd();
 }
 
-Error AsmI8080::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmI8080::encode(Insn<Config> &_insn) {
     InsnI8080 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_i8080.cpp
+++ b/src/asm_i8080.cpp
@@ -112,7 +112,7 @@ Error AsmI8080::encodeIoaddr(InsnI8080 &insn) {
     return checkLineEnd();
 }
 
-Error AsmI8080::encode(Insn &_insn) {
+Error AsmI8080::encode(Insn<Config::uintptr_t> &_insn) {
     InsnI8080 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_i8080.h
+++ b/src/asm_i8080.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace i8080 {
 
-class AsmI8080 : public Assembler<target::uintptr_t> {
+class AsmI8080 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
@@ -51,7 +51,7 @@ private:
     Error encodeDirect(InsnI8080 &insn);
     Error encodeIoaddr(InsnI8080 &insn);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace i8080

--- a/src/asm_i8080.h
+++ b/src/asm_i8080.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
     const char *listCpu() const override { return TableI8080::listCpu(); }
     Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;

--- a/src/asm_i8080.h
+++ b/src/asm_i8080.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace i8080 {
 
-class AsmI8080 : public Assembler<Config::uintptr_t> {
+class AsmI8080 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
     const char *listCpu() const override { return TableI8080::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;
@@ -51,7 +48,7 @@ private:
     Error encodeDirect(InsnI8080 &insn);
     Error encodeIoaddr(InsnI8080 &insn);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace i8080

--- a/src/asm_interface.h
+++ b/src/asm_interface.h
@@ -31,7 +31,7 @@ public:
     typedef Addr addr_t;
 
     Error encode(
-        const char *line, Insn &insn, Addr addr,SymbolTable *symtab) {
+        const char *line, Insn<Addr> &insn, Addr addr,SymbolTable *symtab) {
         this->resetError();
         _scan = skipSpaces(line);
         if (checkLineEnd() == OK)
@@ -104,7 +104,7 @@ protected:
     }
 
 private:
-    virtual Error encode(Insn &insn) = 0;
+    virtual Error encode(Insn<Addr> &insn) = 0;
 };
 
 } // namespace libasm

--- a/src/asm_interface.h
+++ b/src/asm_interface.h
@@ -25,13 +25,13 @@
 
 namespace libasm {
 
-template<typename Addr>
+template<typename Conf>
 class Assembler : public ErrorReporter {
-public:
-    typedef Addr addr_t;
+    typedef typename Conf::uintptr_t addr_t;
 
+public:
     Error encode(
-        const char *line, Insn<Addr> &insn, Addr addr,SymbolTable *symtab) {
+        const char *line, Insn<Conf> &insn, addr_t addr, SymbolTable *symtab) {
         this->resetError();
         _scan = skipSpaces(line);
         if (checkLineEnd() == OK)
@@ -45,9 +45,9 @@ public:
     const char *errorAt() const { return _scan; }
     virtual bool setCpu(const char *cpu) = 0;
     virtual const char *listCpu() const = 0;
-    virtual Endian endian() const = 0;
-    virtual host::uint_t maxBytes() const = 0;
-    virtual host::uint_t maxName() const = 0;
+    Endian endian() const { return Conf::endian; }
+    host::uint_t maxBytes() const { return Conf::code_max; }
+    host::uint_t maxName() const { return Conf::name_max; }
 
 protected:
     const char *_scan;
@@ -104,7 +104,7 @@ protected:
     }
 
 private:
-    virtual Error encode(Insn<Addr> &insn) = 0;
+    virtual Error encode(Insn<Conf> &insn) = 0;
 };
 
 } // namespace libasm

--- a/src/asm_m6502.cpp
+++ b/src/asm_m6502.cpp
@@ -33,11 +33,11 @@ Error AsmM6502::encodeLongRelative(InsnM6502 &insn) {
 }
 
 Error AsmM6502::encodeRelative(InsnM6502 &insn, bool emitInsn) {
-    target::uintptr_t addr;
+    Config::uintptr_t addr;
     if (getOperand16(addr)) return getError();
     if (getError() == UNDEFINED_SYMBOL) addr = insn.address();
-    const target::uintptr_t base = insn.address() + (emitInsn ? 2 : 3);
-    const target::ptrdiff_t delta = addr - base;
+    const Config::uintptr_t base = insn.address() + (emitInsn ? 2 : 3);
+    const Config::ptrdiff_t delta = addr - base;
     if (emitInsn) insn.emitInsn();
     if (delta >= 128 || delta < -128) return setError(OPERAND_TOO_FAR);
     insn.emitByte(static_cast<uint8_t>(delta));
@@ -177,7 +177,7 @@ Error AsmM6502::parseOperand(Operand &op) {
     return setError(OK);
 }
 
-Error AsmM6502::encode(Insn &_insn) {
+Error AsmM6502::encode(Insn<Config::uintptr_t> &_insn) {
     InsnM6502 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_m6502.cpp
+++ b/src/asm_m6502.cpp
@@ -177,7 +177,7 @@ Error AsmM6502::parseOperand(Operand &op) {
     return setError(OK);
 }
 
-Error AsmM6502::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmM6502::encode(Insn<Config> &_insn) {
     InsnM6502 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_m6502.h
+++ b/src/asm_m6502.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace m6502 {
 
-class AsmM6502 : public Assembler<target::uintptr_t> {
+class AsmM6502 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
@@ -54,7 +54,7 @@ private:
     Error encodeZeroPageRelative(InsnM6502 &insn);
     Error encodeBlockMove(InsnM6502 &insn);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace m6502

--- a/src/asm_m6502.h
+++ b/src/asm_m6502.h
@@ -32,9 +32,9 @@ public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
     const char *listCpu() const override { return TableM6502::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    Endian endian() const override { return Config::endian; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;

--- a/src/asm_m6502.h
+++ b/src/asm_m6502.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace m6502 {
 
-class AsmM6502 : public Assembler<Config::uintptr_t> {
+class AsmM6502 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
     const char *listCpu() const override { return TableM6502::listCpu(); }
-    Endian endian() const override { return Config::endian; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;
@@ -54,7 +51,7 @@ private:
     Error encodeZeroPageRelative(InsnM6502 &insn);
     Error encodeBlockMove(InsnM6502 &insn);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace m6502

--- a/src/asm_mc6800.cpp
+++ b/src/asm_mc6800.cpp
@@ -176,7 +176,7 @@ Error AsmMc6800::determineAddrMode(const char *line, InsnMc6800 &insn) {
     return OK;
 }
 
-Error AsmMc6800::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmMc6800::encode(Insn<Config> &_insn) {
     InsnMc6800 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_mc6800.cpp
+++ b/src/asm_mc6800.cpp
@@ -55,7 +55,7 @@ Error AsmMc6800::encodeDirect(InsnMc6800 &insn) {
     }
     if (*_scan == '<') _scan++;
     insn.emitInsn();
-    target::uintptr_t dir;
+    Config::uintptr_t dir;
     if (getOperand16(dir)) return getError();
     // TODO: Warning if dir isn't on _direct_page.
     insn.emitByte(static_cast<uint8_t>(dir));
@@ -69,7 +69,7 @@ Error AsmMc6800::encodeExtended(InsnMc6800 &insn) {
     }
     if (*_scan == '>') _scan++;
     insn.emitInsn();
-    target::uintptr_t addr;
+    Config::uintptr_t addr;
     if (getOperand16(addr)) return getError();
     insn.emitUint16(addr);
     return checkLineEnd();
@@ -96,11 +96,11 @@ Error AsmMc6800::encodeIndexed(InsnMc6800 &insn) {
 }
 
 Error AsmMc6800::encodeRelative(InsnMc6800 &insn) {
-    target::uintptr_t addr;
+    Config::uintptr_t addr;
     if (getOperand16(addr)) return getError();
     if (getError() == UNDEFINED_SYMBOL) addr = insn.address();
-    const target::uintptr_t base = insn.address() + 2;
-    const target::ptrdiff_t delta = addr - base;
+    const Config::uintptr_t base = insn.address() + 2;
+    const Config::ptrdiff_t delta = addr - base;
     insn.emitInsn();
     if (delta >= 128 || delta < -128) return setError(OPERAND_TOO_FAR);
     insn.emitByte(static_cast<uint8_t>(delta));
@@ -176,7 +176,7 @@ Error AsmMc6800::determineAddrMode(const char *line, InsnMc6800 &insn) {
     return OK;
 }
 
-Error AsmMc6800::encode(Insn &_insn) {
+Error AsmMc6800::encode(Insn<Config::uintptr_t> &_insn) {
     InsnMc6800 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_mc6800.h
+++ b/src/asm_mc6800.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace mc6800 {
 
-class AsmMc6800 : public Assembler<Config::uintptr_t> {
+class AsmMc6800 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6800::listCpu(); }
-    Endian endian() const override { return Config::endian; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;
@@ -50,7 +47,7 @@ private:
     Error encodeRelative(InsnMc6800 &insn);
     Error encodeImmediate(InsnMc6800 &insn);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace m6502

--- a/src/asm_mc6800.h
+++ b/src/asm_mc6800.h
@@ -32,9 +32,9 @@ public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6800::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    Endian endian() const override { return Config::endian; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;

--- a/src/asm_mc6800.h
+++ b/src/asm_mc6800.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace mc6800 {
 
-class AsmMc6800 : public Assembler<target::uintptr_t> {
+class AsmMc6800 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
@@ -50,7 +50,7 @@ private:
     Error encodeRelative(InsnMc6800 &insn);
     Error encodeImmediate(InsnMc6800 &insn);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace m6502

--- a/src/asm_mc68000.cpp
+++ b/src/asm_mc68000.cpp
@@ -828,7 +828,7 @@ Error AsmMc68000::parseOperand(Operand &opr) {
     return setError(OK);
 }
 
-Error AsmMc68000::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmMc68000::encode(Insn<Config> &_insn) {
     InsnMc68000 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_mc68000.h
+++ b/src/asm_mc68000.h
@@ -26,14 +26,11 @@
 namespace libasm {
 namespace mc68000 {
 
-class AsmMc68000 : public Assembler<Config::uintptr_t> {
+class AsmMc68000 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
     const char *listCpu() const override { return TableMc68000::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;
@@ -111,7 +108,7 @@ private:
     Error encodeMoveOpr(
         InsnMc68000 &insn, const Operand &op1, const Operand &op2);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace mc68000

--- a/src/asm_mc68000.h
+++ b/src/asm_mc68000.h
@@ -32,8 +32,8 @@ public:
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
     const char *listCpu() const override { return TableMc68000::listCpu(); }
     Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;

--- a/src/asm_mc68000.h
+++ b/src/asm_mc68000.h
@@ -26,7 +26,7 @@
 namespace libasm {
 namespace mc68000 {
 
-class AsmMc68000 : public Assembler<target::uintptr_t> {
+class AsmMc68000 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
@@ -111,7 +111,7 @@ private:
     Error encodeMoveOpr(
         InsnMc68000 &insn, const Operand &op1, const Operand &op2);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace mc68000

--- a/src/asm_mc6809.cpp
+++ b/src/asm_mc6809.cpp
@@ -459,7 +459,7 @@ Error AsmMc6809::processPseudo(InsnMc6809 &insn) {
     return setError(UNKNOWN_INSTRUCTION);
 }
 
-Error AsmMc6809::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmMc6809::encode(Insn<Config> &_insn) {
     InsnMc6809 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_mc6809.h
+++ b/src/asm_mc6809.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace mc6809 {
 
-class AsmMc6809 : public Assembler<target::uintptr_t> {
+class AsmMc6809 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
@@ -57,7 +57,7 @@ private:
     Error encodeTransferMemory(InsnMc6809 &insn);
     // Pseudo instruction
     Error processPseudo(InsnMc6809 &insn);
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace mc6809

--- a/src/asm_mc6809.h
+++ b/src/asm_mc6809.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace mc6809 {
 
-class AsmMc6809 : public Assembler<Config::uintptr_t> {
+class AsmMc6809 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6809::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;
@@ -57,7 +54,7 @@ private:
     Error encodeTransferMemory(InsnMc6809 &insn);
     // Pseudo instruction
     Error processPseudo(InsnMc6809 &insn);
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace mc6809

--- a/src/asm_mc6809.h
+++ b/src/asm_mc6809.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6809::listCpu(); }
     Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmMotoOperand _parser;

--- a/src/asm_tms9900.cpp
+++ b/src/asm_tms9900.cpp
@@ -146,7 +146,7 @@ Error AsmTms9900::encodeCruOff(InsnTms9900 &insn) {
     return getError();
 }
 
-Error AsmTms9900::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmTms9900::encode(Insn<Config> &_insn) {
     InsnTms9900 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_tms9900.cpp
+++ b/src/asm_tms9900.cpp
@@ -126,12 +126,12 @@ Error AsmTms9900::encodeOpr(
 }
 
 Error AsmTms9900::encodeRel(InsnTms9900 &insn) {
-    target::uintptr_t addr;
+    Config::uintptr_t addr;
     if (getOperand16(addr)) return getError();
     if (getError() == UNDEFINED_SYMBOL) addr = insn.address();
     if (addr % 2) return setError(ILLEGAL_OPERAND);
-    const target::uintptr_t base = insn.address() + 2;
-    const target::ptrdiff_t delta = (addr - base) >> 1;
+    const Config::uintptr_t base = insn.address() + 2;
+    const Config::ptrdiff_t delta = (addr - base) >> 1;
     if (delta >= 128 || delta < -128) return setError(OPERAND_TOO_FAR);
     insn.embed(static_cast<uint8_t>(delta));
     insn.emitInsn();
@@ -146,7 +146,7 @@ Error AsmTms9900::encodeCruOff(InsnTms9900 &insn) {
     return getError();
 }
 
-Error AsmTms9900::encode(Insn &_insn) {
+Error AsmTms9900::encode(Insn<Config::uintptr_t> &_insn) {
     InsnTms9900 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_tms9900.h
+++ b/src/asm_tms9900.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
     const char *listCpu() const override { return TableTms9900::listCpu(); }
     Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;

--- a/src/asm_tms9900.h
+++ b/src/asm_tms9900.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace tms9900 {
 
-class AsmTms9900 : public Assembler<Config::uintptr_t> {
+class AsmTms9900 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
     const char *listCpu() const override { return TableTms9900::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;
@@ -51,7 +48,7 @@ private:
     Error encodeCruOff(InsnTms9900 &insn);
     Error encodeIoaddr(InsnTms9900 &insn);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace tms9900

--- a/src/asm_tms9900.h
+++ b/src/asm_tms9900.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace tms9900 {
 
-class AsmTms9900 : public Assembler<target::uintptr_t> {
+class AsmTms9900 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
@@ -51,7 +51,7 @@ private:
     Error encodeCruOff(InsnTms9900 &insn);
     Error encodeIoaddr(InsnTms9900 &insn);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace tms9900

--- a/src/asm_z80.cpp
+++ b/src/asm_z80.cpp
@@ -368,7 +368,7 @@ Error AsmZ80::parseOperand(const InsnZ80 &insn, Operand &opr) {
     return OK;
 }
 
-Error AsmZ80::encode(Insn<Config::uintptr_t> &_insn) {
+Error AsmZ80::encode(Insn<Config> &_insn) {
     InsnZ80 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_z80.cpp
+++ b/src/asm_z80.cpp
@@ -92,14 +92,14 @@ Error AsmZ80::encodeIoaddr(
 
 Error AsmZ80::encodeRelative(
     InsnZ80 &insn, const Operand &left, const Operand &right) {
-    target::uintptr_t addr = left.val;
+    Config::uintptr_t addr = left.val;
     if (left.getError() == UNDEFINED_SYMBOL) addr = insn.address();
     if (insn.insnFormat() == CC4_FMT) {
         insn.embed(left.val << 3);
         addr = right.val;
         if (right.getError() == UNDEFINED_SYMBOL) addr = insn.address();
     }
-    const target::ptrdiff_t delta = addr - insn.address() - 2;
+    const Config::ptrdiff_t delta = addr - insn.address() - 2;
     if (delta < -128 || delta >= 128) return setError(OPERAND_TOO_FAR);
     insn.emitInsn();
     insn.emitByte(static_cast<uint8_t>(delta));
@@ -143,7 +143,7 @@ Error AsmZ80::encodeIndexed(
 
 Error AsmZ80::encodeIndexedImmediate8(
     InsnZ80 &insn, const Operand &left, const Operand &right) {
-    target::opcode_t opc = insn.opCode();
+    Config::opcode_t opc = insn.opCode();
     insn.setInsnCode(0, insn.prefixCode());
     if (left.format == IX_OFF)
         RegZ80::encodeIndexReg(insn, left.reg);
@@ -368,7 +368,7 @@ Error AsmZ80::parseOperand(const InsnZ80 &insn, Operand &opr) {
     return OK;
 }
 
-Error AsmZ80::encode(Insn &_insn) {
+Error AsmZ80::encode(Insn<Config::uintptr_t> &_insn) {
     InsnZ80 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);

--- a/src/asm_z80.h
+++ b/src/asm_z80.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace z80 {
 
-class AsmZ80 : public Assembler<Config::uintptr_t> {
+class AsmZ80 : public Assembler<Config> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
     const char *listCpu() const override { return TableZ80::listCpu(); }
-    Endian endian() const override { return Config::endian; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;
@@ -64,7 +61,7 @@ private:
     Error encodeIndexedImmediate8(
         InsnZ80 &insn, const Operand &left, const Operand &right);
 
-    Error encode(Insn<Config::uintptr_t> &insn) override;
+    Error encode(Insn<Config> &insn) override;
 };
 
 } // namespace z80

--- a/src/asm_z80.h
+++ b/src/asm_z80.h
@@ -32,9 +32,9 @@ public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
     const char *listCpu() const override { return TableZ80::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    Endian endian() const override { return Config::endian; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     AsmIntelOperand _parser;

--- a/src/asm_z80.h
+++ b/src/asm_z80.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace z80 {
 
-class AsmZ80 : public Assembler<target::uintptr_t> {
+class AsmZ80 : public Assembler<Config::uintptr_t> {
 public:
     AsmOperand &getParser() override { return _parser; }
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
@@ -64,7 +64,7 @@ private:
     Error encodeIndexedImmediate8(
         InsnZ80 &insn, const Operand &left, const Operand &right);
 
-    Error encode(Insn &insn) override;
+    Error encode(Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace z80

--- a/src/config_base.h
+++ b/src/config_base.h
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
-#ifndef __CONFIG_MC68000_H__
-#define __CONFIG_MC68000_H__
+#ifndef __CONFIG_BASE_H__
+#define __CONFIG_BASE_H__
 
-#include "config_base.h"
+#include "config_host.h"
 
 namespace libasm {
-namespace mc68000 {
 
-struct Config {
-    typedef uint32_t uintptr_t;
-    typedef int32_t  ptrdiff_t;
-    typedef uint16_t opcode_t;
-    typedef uint16_t insn_t;
-
-    static constexpr Endian endian = ENDIAN_BIG;
-    static constexpr host::uint_t code_max = 10;
-    static constexpr host::uint_t name_max = 7;
+enum Endian : host::uint_t {
+    ENDIAN_BIG,
+    ENDIAN_LITTLE,
 };
 
-} // namespace mc68000
 } // namespace libasm
 
-#endif // __CONFIG_MC68000_H__
+#endif // __CONFIG_BASE_H__
 
 // Local Variables:
 // mode: c++

--- a/src/config_base.h
+++ b/src/config_base.h
@@ -26,6 +26,26 @@ enum Endian : host::uint_t {
     ENDIAN_LITTLE,
 };
 
+template<
+    typename AddrT,
+    typename DiffT,
+    typename OpCodeT,
+    typename InsnT,
+    Endian EndianE,
+    host::uint_t CodeMax,
+    host::uint_t NameMax
+    >
+struct ConfigBase {
+    typedef AddrT   uintptr_t;
+    typedef DiffT   ptrdiff_t;
+    typedef OpCodeT opcode_t;
+    typedef InsnT   insn_t;
+
+    static constexpr Endian endian = EndianE;
+    static constexpr host::uint_t code_max = CodeMax;
+    static constexpr host::uint_t name_max = NameMax;
+};
+
 } // namespace libasm
 
 #endif // __CONFIG_BASE_H__

--- a/src/config_i8080.h
+++ b/src/config_i8080.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_I8080_H__
 #define __CONFIG_I8080_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace i8080 {
@@ -27,6 +27,10 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
+
+    static constexpr Endian endian = ENDIAN_LITTLE;
+    static constexpr host::uint_t code_max = 3;
+    static constexpr host::uint_t name_max = 4;
 };
 
 } // namespace i8080

--- a/src/config_i8080.h
+++ b/src/config_i8080.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace i8080 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint8_t  opcode_t;
-    typedef uint8_t  insn_t;
-
-    static constexpr Endian endian = ENDIAN_LITTLE;
-    static constexpr host::uint_t code_max = 3;
-    static constexpr host::uint_t name_max = 4;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint8_t, uint8_t,
+    ENDIAN_LITTLE, 3, 4>
+{};
 
 } // namespace i8080
 } // namespace libasm

--- a/src/config_i8080.h
+++ b/src/config_i8080.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace i8080 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
-} // namespace target
+};
+
+} // namespace i8080
+} // namespace libasm
 
 #endif // __CONFIG_I8080_H__
 

--- a/src/config_m6502.h
+++ b/src/config_m6502.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace m6502 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint8_t  opcode_t;
-    typedef uint8_t  insn_t;
-
-    static constexpr Endian endian = ENDIAN_LITTLE;
-    static constexpr host::uint_t code_max = 4;
-    static constexpr host::uint_t name_max = 4;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint8_t, uint8_t,
+    ENDIAN_LITTLE, 4, 4>
+{};
 
 enum CpuType : host::uint_t {
     M6502,

--- a/src/config_m6502.h
+++ b/src/config_m6502.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_M6502_H__
 #define __CONFIG_M6502_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace m6502 {
@@ -27,6 +27,19 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
+
+    static constexpr Endian endian = ENDIAN_LITTLE;
+    static constexpr host::uint_t code_max = 4;
+    static constexpr host::uint_t name_max = 4;
+};
+
+enum CpuType : host::uint_t {
+    M6502,
+    W65SC02,
+    R65C02BIT,
+    R65C02,
+    W65C02S,
+    W65C816,
 };
 
 } // namespace m6502

--- a/src/config_m6502.h
+++ b/src/config_m6502.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace m6502 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
-} // namespace target
+};
+
+} // namespace m6502
+} // namespace libasm
 
 #endif // __CONFIG_M6502_H__
 

--- a/src/config_mc6800.h
+++ b/src/config_mc6800.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_MC6800_H__
 #define __CONFIG_MC6800_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace mc6800 {
@@ -27,6 +27,10 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
+
+    static constexpr Endian endian = ENDIAN_BIG;
+    static constexpr host::uint_t code_max = 3;
+    static constexpr host::uint_t name_max = 3;
 };
 
 } // namespace mc6800

--- a/src/config_mc6800.h
+++ b/src/config_mc6800.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace mc6800 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint8_t  insn_t;
-} // namespace target
+};
+
+} // namespace mc6800
+} // namespace libasm
 
 #endif // __CONFIG_MC6800_H__
 

--- a/src/config_mc6800.h
+++ b/src/config_mc6800.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace mc6800 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint8_t  opcode_t;
-    typedef uint8_t  insn_t;
-
-    static constexpr Endian endian = ENDIAN_BIG;
-    static constexpr host::uint_t code_max = 3;
-    static constexpr host::uint_t name_max = 3;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint8_t, uint8_t,
+    ENDIAN_BIG, 3, 3>
+{};
 
 } // namespace mc6800
 } // namespace libasm

--- a/src/config_mc68000.h
+++ b/src/config_mc68000.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace mc68000 {
+
+struct Config {
     typedef uint32_t uintptr_t;
     typedef int32_t  ptrdiff_t;
     typedef uint16_t opcode_t;
     typedef uint16_t insn_t;
-} // namespace target
+};
+
+} // namespace mc68000
+} // namespace libasm
 
 #endif // __CONFIG_MC68000_H__
 

--- a/src/config_mc68000.h
+++ b/src/config_mc68000.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace mc68000 {
 
-struct Config {
-    typedef uint32_t uintptr_t;
-    typedef int32_t  ptrdiff_t;
-    typedef uint16_t opcode_t;
-    typedef uint16_t insn_t;
-
-    static constexpr Endian endian = ENDIAN_BIG;
-    static constexpr host::uint_t code_max = 10;
-    static constexpr host::uint_t name_max = 7;
-};
+struct Config : ConfigBase<
+    uint32_t, int32_t, uint16_t, uint16_t,
+    ENDIAN_BIG, 10, 7>
+{};
 
 } // namespace mc68000
 } // namespace libasm

--- a/src/config_mc6809.h
+++ b/src/config_mc6809.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace mc6809 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint8_t  opcode_t;
-    typedef uint16_t insn_t;
-
-    static constexpr Endian endian = ENDIAN_BIG;
-    static constexpr host::uint_t code_max = 5;
-    static constexpr host::uint_t name_max = 6;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint8_t, uint16_t,
+    ENDIAN_BIG, 5, 6>
+{};
 
 enum CpuType : host::uint_t {
     MC6809,

--- a/src/config_mc6809.h
+++ b/src/config_mc6809.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_MC6809_H__
 #define __CONFIG_MC6809_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace mc6809 {
@@ -27,6 +27,15 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint16_t insn_t;
+
+    static constexpr Endian endian = ENDIAN_BIG;
+    static constexpr host::uint_t code_max = 5;
+    static constexpr host::uint_t name_max = 6;
+};
+
+enum CpuType : host::uint_t {
+    MC6809,
+    HD6309,
 };
 
 } // namespace mc6809

--- a/src/config_mc6809.h
+++ b/src/config_mc6809.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace mc6809 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint16_t insn_t;
-} // namespace target
+};
+
+} // namespace mc6809
+} // namespace libasm
 
 #endif // __CONFIG_MC6809_H__
 

--- a/src/config_tms9900.h
+++ b/src/config_tms9900.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace tms9900 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint16_t opcode_t;
     typedef uint16_t insn_t;
-} // namespace target
+};
+
+} // namespace tms9900
+} // namespace libasm
 
 #endif // __CONFIG_TMS9900_H__
 

--- a/src/config_tms9900.h
+++ b/src/config_tms9900.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_TMS9900_H__
 #define __CONFIG_TMS9900_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace tms9900 {
@@ -27,6 +27,15 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint16_t opcode_t;
     typedef uint16_t insn_t;
+
+    static constexpr Endian endian = ENDIAN_BIG;
+    static constexpr host::uint_t code_max = 6;
+    static constexpr host::uint_t name_max = 4;
+};
+
+enum CpuType : host::uint_t {
+    TMS9900,
+    TMS9995,
 };
 
 } // namespace tms9900

--- a/src/config_tms9900.h
+++ b/src/config_tms9900.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace tms9900 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint16_t opcode_t;
-    typedef uint16_t insn_t;
-
-    static constexpr Endian endian = ENDIAN_BIG;
-    static constexpr host::uint_t code_max = 6;
-    static constexpr host::uint_t name_max = 4;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint16_t, uint16_t,
+    ENDIAN_BIG, 6, 4>
+{};
 
 enum CpuType : host::uint_t {
     TMS9900,

--- a/src/config_z80.h
+++ b/src/config_z80.h
@@ -17,7 +17,7 @@
 #ifndef __CONFIG_Z80_H__
 #define __CONFIG_Z80_H__
 
-#include "config_host.h"
+#include "config_base.h"
 
 namespace libasm {
 namespace z80 {
@@ -27,6 +27,15 @@ struct Config {
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint16_t insn_t;
+
+    static constexpr Endian endian = ENDIAN_LITTLE;
+    static constexpr host::uint_t code_max = 4;
+    static constexpr host::uint_t name_max = 4;
+};
+
+enum CpuType : host::uint_t {
+    Z80,
+    I8080,
 };
 
 } // namespace z80

--- a/src/config_z80.h
+++ b/src/config_z80.h
@@ -22,16 +22,10 @@
 namespace libasm {
 namespace z80 {
 
-struct Config {
-    typedef uint16_t uintptr_t;
-    typedef int16_t  ptrdiff_t;
-    typedef uint8_t  opcode_t;
-    typedef uint16_t insn_t;
-
-    static constexpr Endian endian = ENDIAN_LITTLE;
-    static constexpr host::uint_t code_max = 4;
-    static constexpr host::uint_t name_max = 4;
-};
+struct Config : ConfigBase<
+    uint16_t, int16_t, uint8_t, uint16_t,
+    ENDIAN_LITTLE, 4, 4>
+{};
 
 enum CpuType : host::uint_t {
     Z80,

--- a/src/config_z80.h
+++ b/src/config_z80.h
@@ -19,13 +19,18 @@
 
 #include "config_host.h"
 
-namespace target
-{
+namespace libasm {
+namespace z80 {
+
+struct Config {
     typedef uint16_t uintptr_t;
     typedef int16_t  ptrdiff_t;
     typedef uint8_t  opcode_t;
     typedef uint16_t insn_t;
-} // namespace target
+};
+
+} // namespace z80
+} // namespace libasm
 
 #endif // __CONFIG_Z80_H__
 

--- a/src/dis_i8080.cpp
+++ b/src/dis_i8080.cpp
@@ -25,7 +25,7 @@ void DisI8080::outRegister(RegName regName) {
 }
 
 Error DisI8080::decodeImmediate8(
-    DisMemory<target::uintptr_t>& memory, InsnI8080 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnI8080 &insn) {
     uint8_t val;
     if (insn.readByte(memory, val)) return setError(NO_MEMORY);
     if (insn.insnFormat() != NO_FORMAT) *_operands++ = ',';
@@ -34,7 +34,7 @@ Error DisI8080::decodeImmediate8(
 }
 
 Error DisI8080::decodeImmediate16(
-    DisMemory<target::uintptr_t>& memory, InsnI8080 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnI8080 &insn) {
     uint16_t val;
     if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
     if (insn.insnFormat() != NO_FORMAT) *_operands++ = ',';
@@ -48,8 +48,8 @@ Error DisI8080::decodeImmediate16(
 }
 
 Error DisI8080::decodeDirect(
-    DisMemory<target::uintptr_t> &memory, InsnI8080& insn) {
-    target::uintptr_t addr;
+    DisMemory<Config::uintptr_t> &memory, InsnI8080& insn) {
+    Config::uintptr_t addr;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     const char *label = lookup(addr);
     if (label) {
@@ -61,7 +61,7 @@ Error DisI8080::decodeDirect(
 }
 
 Error DisI8080::decodeIoaddr(
-    DisMemory<target::uintptr_t> &memory, InsnI8080& insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnI8080& insn) {
     uint8_t ioaddr;
     if (insn.readByte(memory, ioaddr)) return setError(NO_MEMORY);
     outConstant(ioaddr, 16, false);
@@ -69,9 +69,9 @@ Error DisI8080::decodeIoaddr(
 }
 
 Error DisI8080::decode(
-    DisMemory<target::uintptr_t> &memory, Insn &_insn) {
+    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
     InsnI8080 insn(_insn);
-    target::insn_t insnCode;
+    Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);
     insn.setInsnCode(insnCode);
     if (TableI8080.searchInsnCode(insn))

--- a/src/dis_i8080.cpp
+++ b/src/dis_i8080.cpp
@@ -25,7 +25,7 @@ void DisI8080::outRegister(RegName regName) {
 }
 
 Error DisI8080::decodeImmediate8(
-    DisMemory<Config::uintptr_t>& memory, InsnI8080 &insn) {
+    DisMemory<Config>& memory, InsnI8080 &insn) {
     uint8_t val;
     if (insn.readByte(memory, val)) return setError(NO_MEMORY);
     if (insn.insnFormat() != NO_FORMAT) *_operands++ = ',';
@@ -34,7 +34,7 @@ Error DisI8080::decodeImmediate8(
 }
 
 Error DisI8080::decodeImmediate16(
-    DisMemory<Config::uintptr_t>& memory, InsnI8080 &insn) {
+    DisMemory<Config>& memory, InsnI8080 &insn) {
     uint16_t val;
     if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
     if (insn.insnFormat() != NO_FORMAT) *_operands++ = ',';
@@ -48,7 +48,7 @@ Error DisI8080::decodeImmediate16(
 }
 
 Error DisI8080::decodeDirect(
-    DisMemory<Config::uintptr_t> &memory, InsnI8080& insn) {
+    DisMemory<Config> &memory, InsnI8080& insn) {
     Config::uintptr_t addr;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     const char *label = lookup(addr);
@@ -61,7 +61,7 @@ Error DisI8080::decodeDirect(
 }
 
 Error DisI8080::decodeIoaddr(
-    DisMemory<Config::uintptr_t> &memory, InsnI8080& insn) {
+    DisMemory<Config> &memory, InsnI8080& insn) {
     uint8_t ioaddr;
     if (insn.readByte(memory, ioaddr)) return setError(NO_MEMORY);
     outConstant(ioaddr, 16, false);
@@ -69,7 +69,7 @@ Error DisI8080::decodeIoaddr(
 }
 
 Error DisI8080::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnI8080 insn(_insn);
     Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);

--- a/src/dis_i8080.h
+++ b/src/dis_i8080.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace i8080 {
 
-class DisI8080 : public Disassembler<Config::uintptr_t> {
+class DisI8080 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
     const char *listCpu() const override { return TableI8080::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;
@@ -43,17 +40,11 @@ private:
     RegBase &getRegister() override { return _regs; }
     void outRegister(RegName regName);
 
-    Error decodeImmediate8(
-        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
-    Error decodeImmediate16(
-        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
-    Error decodeDirect(
-        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
-    Error decodeIoaddr(
-        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory,
-        Insn<Config::uintptr_t> &insn) override;
+    Error decodeImmediate8(DisMemory<Config> &memory, InsnI8080 &insn);
+    Error decodeImmediate16(DisMemory<Config> &memory, InsnI8080 &insn);
+    Error decodeDirect(DisMemory<Config> &memory, InsnI8080 &insn);
+    Error decodeIoaddr(DisMemory<Config> &memory, InsnI8080 &insn);
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace i8080

--- a/src/dis_i8080.h
+++ b/src/dis_i8080.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace i8080 {
 
-class DisI8080 : public Disassembler<target::uintptr_t> {
+class DisI8080 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
@@ -44,15 +44,16 @@ private:
     void outRegister(RegName regName);
 
     Error decodeImmediate8(
-        DisMemory<target::uintptr_t> &memory, InsnI8080 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
     Error decodeImmediate16(
-        DisMemory<target::uintptr_t> &memory, InsnI8080 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
     Error decodeDirect(
-        DisMemory<target::uintptr_t> &memory, InsnI8080 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
     Error decodeIoaddr(
-        DisMemory<target::uintptr_t> &memory, InsnI8080 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnI8080 &insn);
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn& insn) override;
+        DisMemory<Config::uintptr_t> &memory,
+        Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace i8080

--- a/src/dis_i8080.h
+++ b/src/dis_i8080.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableI8080.setCpu(cpu); }
     const char *listCpu() const override { return TableI8080::listCpu(); }
     Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;

--- a/src/dis_interface.h
+++ b/src/dis_interface.h
@@ -26,13 +26,12 @@
 
 namespace libasm {
 
-template<typename Addr>
+template<typename Conf>
 class Disassembler : public ErrorReporter {
 public:
-    typedef Addr addr_t;
 
     Error decode(
-        DisMemory<Addr> &memory, Insn<Addr> &insn,
+        DisMemory<Conf> &memory, Insn<Conf> &insn,
         char *operands, SymbolTable *symtab, bool uppercase = false) {
         insn.resetAddress(memory.address());
         *(_operands = operands) = 0;
@@ -47,9 +46,6 @@ public:
     virtual DisOperand &getFormatter() = 0;
     virtual bool setCpu(const char *cpu) = 0;
     virtual const char *listCpu() const = 0;
-    virtual Endian endian() const = 0;
-    virtual host::uint_t maxBytes() const = 0;
-    virtual host::uint_t maxName() const = 0;
 
 protected:
     char *_operands;
@@ -60,8 +56,8 @@ protected:
         if (_symtab) {
             symbol = _symtab->lookup(addr);
             if (!symbol) {
-                auto value =
-                    static_cast<typename make_signed<Addr>::type>(addr);
+                auto value = static_cast<
+                    typename make_signed<typename Conf::uintptr_t>::type>(addr);
                 symbol = _symtab->lookup(static_cast<int32_t>(value));
             }
         }
@@ -83,7 +79,7 @@ protected:
 
 private:
     virtual RegBase &getRegister();
-    virtual Error decode(DisMemory<Addr> &memory, Insn<Addr> &insn) = 0;
+    virtual Error decode(DisMemory<Conf> &memory, Insn<Conf> &insn) = 0;
 };
 
 } // namespace libasm

--- a/src/dis_interface.h
+++ b/src/dis_interface.h
@@ -32,7 +32,7 @@ public:
     typedef Addr addr_t;
 
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn& insn,
+        DisMemory<Addr> &memory, Insn<Addr> &insn,
         char *operands, SymbolTable *symtab, bool uppercase = false) {
         insn.resetAddress(memory.address());
         *(_operands = operands) = 0;
@@ -83,8 +83,7 @@ protected:
 
 private:
     virtual RegBase &getRegister();
-    virtual Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn& insn) = 0;
+    virtual Error decode(DisMemory<Addr> &memory, Insn<Addr> &insn) = 0;
 };
 
 } // namespace libasm

--- a/src/dis_m6502.cpp
+++ b/src/dis_m6502.cpp
@@ -21,7 +21,7 @@ namespace libasm {
 namespace m6502 {
 
 Error DisM6502::decodeImmediate(
-    DisMemory<Config::uintptr_t>& memory, InsnM6502 &insn) {
+    DisMemory<Config>& memory, InsnM6502 &insn) {
     uint8_t val;
     if (insn.readByte(memory, val)) return setError(NO_MEMORY);
     *_operands++ = '#';
@@ -35,7 +35,7 @@ Error DisM6502::decodeImmediate(
 }
 
 Error DisM6502::decodeAbsolute(
-    DisMemory<Config::uintptr_t>& memory, InsnM6502 &insn) {
+    DisMemory<Config>& memory, InsnM6502 &insn) {
     const AddrMode addrMode = insn.addrMode();
     const bool indirect = addrMode == ABS_IDX_IDIR
         || addrMode == ABS_IDIR
@@ -92,7 +92,7 @@ Error DisM6502::decodeAbsolute(
 }
 
 Error DisM6502::decodeZeroPage(
-    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
+    DisMemory<Config> &memory, InsnM6502 &insn) {
     const AddrMode addrMode = insn.addrMode();
     const bool indirect = addrMode == ZPG_IDX_IDIR
         || addrMode == ZPG_IDIR_IDY
@@ -150,7 +150,7 @@ Error DisM6502::decodeZeroPage(
 }
 
 Error DisM6502::decodeRelative(
-    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
+    DisMemory<Config> &memory, InsnM6502 &insn) {
     Config::uintptr_t addr;
     if (insn.addrMode() == REL_LONG) {
         uint16_t val;
@@ -172,7 +172,7 @@ Error DisM6502::decodeRelative(
 }
 
 Error DisM6502::decodeBlockMove(
-    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
+    DisMemory<Config> &memory, InsnM6502 &insn) {
     uint8_t srcpg, dstpg;
     if (insn.readByte(memory, srcpg)) return setError(NO_MEMORY);
     if (insn.readByte(memory, dstpg)) return setError(NO_MEMORY);
@@ -183,7 +183,7 @@ Error DisM6502::decodeBlockMove(
 }
 
 Error DisM6502::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnM6502 insn(_insn);
     Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);

--- a/src/dis_m6502.cpp
+++ b/src/dis_m6502.cpp
@@ -21,7 +21,7 @@ namespace libasm {
 namespace m6502 {
 
 Error DisM6502::decodeImmediate(
-    DisMemory<target::uintptr_t>& memory, InsnM6502 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnM6502 &insn) {
     uint8_t val;
     if (insn.readByte(memory, val)) return setError(NO_MEMORY);
     *_operands++ = '#';
@@ -35,7 +35,7 @@ Error DisM6502::decodeImmediate(
 }
 
 Error DisM6502::decodeAbsolute(
-    DisMemory<target::uintptr_t>& memory, InsnM6502 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnM6502 &insn) {
     const AddrMode addrMode = insn.addrMode();
     const bool indirect = addrMode == ABS_IDX_IDIR
         || addrMode == ABS_IDIR
@@ -57,7 +57,7 @@ Error DisM6502::decodeAbsolute(
         index = REG_UNDEF;
         break;
     }
-    target::uintptr_t addr;
+    Config::uintptr_t addr;
     uint32_t target;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     target = addr;
@@ -92,7 +92,7 @@ Error DisM6502::decodeAbsolute(
 }
 
 Error DisM6502::decodeZeroPage(
-    DisMemory<target::uintptr_t> &memory, InsnM6502 &insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
     const AddrMode addrMode = insn.addrMode();
     const bool indirect = addrMode == ZPG_IDX_IDIR
         || addrMode == ZPG_IDIR_IDY
@@ -150,8 +150,8 @@ Error DisM6502::decodeZeroPage(
 }
 
 Error DisM6502::decodeRelative(
-    DisMemory<target::uintptr_t> &memory, InsnM6502 &insn) {
-    target::uintptr_t addr;
+    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
+    Config::uintptr_t addr;
     if (insn.addrMode() == REL_LONG) {
         uint16_t val;
         if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
@@ -172,7 +172,7 @@ Error DisM6502::decodeRelative(
 }
 
 Error DisM6502::decodeBlockMove(
-    DisMemory<target::uintptr_t> &memory, InsnM6502 &insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn) {
     uint8_t srcpg, dstpg;
     if (insn.readByte(memory, srcpg)) return setError(NO_MEMORY);
     if (insn.readByte(memory, dstpg)) return setError(NO_MEMORY);
@@ -183,9 +183,9 @@ Error DisM6502::decodeBlockMove(
 }
 
 Error DisM6502::decode(
-    DisMemory<target::uintptr_t> &memory, Insn &_insn) {
+    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
     InsnM6502 insn(_insn);
-    target::insn_t insnCode;
+    Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);
     insn.setInsnCode(insnCode);
 

--- a/src/dis_m6502.h
+++ b/src/dis_m6502.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace m6502 {
 
-class DisM6502 : public Disassembler<target::uintptr_t> {
+class DisM6502 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
@@ -46,17 +46,17 @@ private:
     RegBase &getRegister() override { return _regs; }
 
     Error decodeImmediate(
-        DisMemory<target::uintptr_t> &memory, InsnM6502 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
     Error decodeAbsolute(
-        DisMemory<target::uintptr_t> &memory, InsnM6502 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
     Error decodeZeroPage(
-        DisMemory<target::uintptr_t> &memory, InsnM6502 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
     Error decodeRelative(
-        DisMemory<target::uintptr_t> &memory, InsnM6502 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
     Error decodeBlockMove(
-        DisMemory<target::uintptr_t> &memory, InsnM6502 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn &insn) override;
+        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace m6502

--- a/src/dis_m6502.h
+++ b/src/dis_m6502.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace m6502 {
 
-class DisM6502 : public Disassembler<Config::uintptr_t> {
+class DisM6502 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
     const char *listCpu() const override { return TableM6502::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
     void acceptIndirectLong(bool accept) { _acceptIndirectLong = accept; }
 
@@ -45,18 +42,12 @@ private:
 
     RegBase &getRegister() override { return _regs; }
 
-    Error decodeImmediate(
-        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
-    Error decodeAbsolute(
-        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
-    Error decodeZeroPage(
-        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
-    Error decodeRelative(
-        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
-    Error decodeBlockMove(
-        DisMemory<Config::uintptr_t> &memory, InsnM6502 &insn);
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &insn) override;
+    Error decodeImmediate(DisMemory<Config> &memory, InsnM6502 &insn);
+    Error decodeAbsolute(DisMemory<Config> &memory, InsnM6502 &insn);
+    Error decodeZeroPage(DisMemory<Config> &memory, InsnM6502 &insn);
+    Error decodeRelative(DisMemory<Config> &memory, InsnM6502 &insn);
+    Error decodeBlockMove(DisMemory<Config> &memory, InsnM6502 &insn);
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace m6502

--- a/src/dis_m6502.h
+++ b/src/dis_m6502.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableM6502.setCpu(cpu); }
     const char *listCpu() const override { return TableM6502::listCpu(); }
     Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
     void acceptIndirectLong(bool accept) { _acceptIndirectLong = accept; }
 

--- a/src/dis_mc6800.cpp
+++ b/src/dis_mc6800.cpp
@@ -25,7 +25,7 @@ void DisMc6800::outRegister(RegName regName) {
 }
 
 bool DisMc6800::outAccumulator(const InsnMc6800 &insn) {
-    const target::opcode_t opc = insn.insnCode();
+    const Config::opcode_t opc = insn.insnCode();
     switch (insn.insnAdjust()) {
     case ADJ_AB01: outRegister((opc & 1) == 0 ? REG_A : REG_B); break;
     case ADJ_AB16: outRegister((opc & 0x10) == 0 ? REG_A : REG_B); break;
@@ -36,13 +36,13 @@ bool DisMc6800::outAccumulator(const InsnMc6800 &insn) {
 }
 
 Error DisMc6800::decodeInherent(
-    DisMemory<target::uintptr_t> &memory, InsnMc6800& insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnMc6800& insn) {
     outAccumulator(insn);
     return setError(OK);
 }
 
 Error DisMc6800::decodeDirectPage(
-    DisMemory<target::uintptr_t> &memory, InsnMc6800& insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnMc6800& insn) {
     uint8_t dir;
     if (insn.readByte(memory, dir)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
@@ -57,8 +57,8 @@ Error DisMc6800::decodeDirectPage(
 }
 
 Error DisMc6800::decodeExtended(
-    DisMemory<target::uintptr_t>& memory, InsnMc6800 &insn) {
-    target::uintptr_t addr;
+    DisMemory<Config::uintptr_t>& memory, InsnMc6800 &insn) {
+    Config::uintptr_t addr;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
     const char *label = lookup(addr);
@@ -72,7 +72,7 @@ Error DisMc6800::decodeExtended(
 }
 
 Error DisMc6800::decodeIndexed(
-    DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn) {
     uint8_t disp8;
     if (insn.readByte(memory, disp8)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
@@ -88,10 +88,10 @@ Error DisMc6800::decodeIndexed(
 }
 
 Error DisMc6800::decodeRelative(
-    DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn) {
+    DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn) {
     uint8_t delta8;
     if (insn.readByte(memory, delta8)) return setError(NO_MEMORY);
-    const target::uintptr_t addr =
+    const Config::uintptr_t addr =
         insn.address() + insn.length() + static_cast<int8_t>(delta8);
     const char *label = lookup(addr);
     if (label) {
@@ -103,7 +103,7 @@ Error DisMc6800::decodeRelative(
 }
 
 Error DisMc6800::decodeImmediate(
-    DisMemory<target::uintptr_t>& memory, InsnMc6800 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnMc6800 &insn) {
     if (outAccumulator(insn)) *_operands++ = ',';
     *_operands++ = '#';
     if (insn.oprSize() == SZ_BYTE) {
@@ -131,9 +131,9 @@ Error DisMc6800::decodeImmediate(
 }
 
 Error DisMc6800::decode(
-    DisMemory<target::uintptr_t> &memory, Insn &_insn) {
+    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
     InsnMc6800 insn(_insn);
-    target::insn_t insnCode;
+    Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);
     insn.setInsnCode(insnCode);
     if (TableMc6800.searchInsnCode(insn))

--- a/src/dis_mc6800.cpp
+++ b/src/dis_mc6800.cpp
@@ -36,13 +36,13 @@ bool DisMc6800::outAccumulator(const InsnMc6800 &insn) {
 }
 
 Error DisMc6800::decodeInherent(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6800& insn) {
+    DisMemory<Config> &memory, InsnMc6800& insn) {
     outAccumulator(insn);
     return setError(OK);
 }
 
 Error DisMc6800::decodeDirectPage(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6800& insn) {
+    DisMemory<Config> &memory, InsnMc6800& insn) {
     uint8_t dir;
     if (insn.readByte(memory, dir)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
@@ -57,7 +57,7 @@ Error DisMc6800::decodeDirectPage(
 }
 
 Error DisMc6800::decodeExtended(
-    DisMemory<Config::uintptr_t>& memory, InsnMc6800 &insn) {
+    DisMemory<Config> &memory, InsnMc6800 &insn) {
     Config::uintptr_t addr;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
@@ -72,7 +72,7 @@ Error DisMc6800::decodeExtended(
 }
 
 Error DisMc6800::decodeIndexed(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn) {
+    DisMemory<Config> &memory, InsnMc6800 &insn) {
     uint8_t disp8;
     if (insn.readByte(memory, disp8)) return setError(NO_MEMORY);
     if (outAccumulator(insn)) *_operands++ = ',';
@@ -88,7 +88,7 @@ Error DisMc6800::decodeIndexed(
 }
 
 Error DisMc6800::decodeRelative(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn) {
+    DisMemory<Config> &memory, InsnMc6800 &insn) {
     uint8_t delta8;
     if (insn.readByte(memory, delta8)) return setError(NO_MEMORY);
     const Config::uintptr_t addr =
@@ -103,7 +103,7 @@ Error DisMc6800::decodeRelative(
 }
 
 Error DisMc6800::decodeImmediate(
-    DisMemory<Config::uintptr_t>& memory, InsnMc6800 &insn) {
+    DisMemory<Config> &memory, InsnMc6800 &insn) {
     if (outAccumulator(insn)) *_operands++ = ',';
     *_operands++ = '#';
     if (insn.oprSize() == SZ_BYTE) {
@@ -131,7 +131,7 @@ Error DisMc6800::decodeImmediate(
 }
 
 Error DisMc6800::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnMc6800 insn(_insn);
     Config::insn_t insnCode;
     if (insn.readByte(memory, insnCode)) return setError(NO_MEMORY);

--- a/src/dis_mc6800.h
+++ b/src/dis_mc6800.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace mc6800 {
 
-class DisMc6800 : public Disassembler<target::uintptr_t> {
+class DisMc6800 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
@@ -45,15 +45,15 @@ private:
     bool outAccumulator(const InsnMc6800 &insn);
 
     // MC6800
-    Error decodeInherent(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeDirectPage(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeExtended(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeIndexed(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeRelative(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeImmediate(DisMemory<target::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeInherent(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeDirectPage(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeExtended(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeIndexed(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeRelative(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeImmediate(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
 
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn& insn) override;
+        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace m6502

--- a/src/dis_mc6800.h
+++ b/src/dis_mc6800.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6800::listCpu(); }
     Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;

--- a/src/dis_mc6800.h
+++ b/src/dis_mc6800.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace mc6800 {
 
-class DisMc6800 : public Disassembler<Config::uintptr_t> {
+class DisMc6800 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc6800.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6800::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;
@@ -45,15 +42,14 @@ private:
     bool outAccumulator(const InsnMc6800 &insn);
 
     // MC6800
-    Error decodeInherent(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeDirectPage(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeExtended(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeIndexed(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeRelative(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
-    Error decodeImmediate(DisMemory<Config::uintptr_t> &memory, InsnMc6800 &insn);
+    Error decodeInherent(DisMemory<Config> &memory, InsnMc6800 &insn);
+    Error decodeDirectPage(DisMemory<Config> &memory, InsnMc6800 &insn);
+    Error decodeExtended(DisMemory<Config> &memory, InsnMc6800 &insn);
+    Error decodeIndexed(DisMemory<Config> &memory, InsnMc6800 &insn);
+    Error decodeRelative(DisMemory<Config> &memory, InsnMc6800 &insn);
+    Error decodeImmediate(DisMemory<Config> &memory, InsnMc6800 &insn);
 
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &insn) override;
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace m6502

--- a/src/dis_mc68000.cpp
+++ b/src/dis_mc68000.cpp
@@ -29,7 +29,7 @@ void DisMc68000::outEaSize(EaSize size) {
 }
 
 Error DisMc68000::decodeImmediateData(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn, EaSize size) {
+    DisMemory<Config> &memory, InsnMc68000 &insn, EaSize size) {
     Error error = OK;
     if (size == SZ_BYTE) {
         uint16_t val16;
@@ -50,7 +50,7 @@ Error DisMc68000::decodeImmediateData(
 }
 
 Error DisMc68000::decodeEffectiveAddr(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn,
+    DisMemory<Config> &memory, InsnMc68000 &insn,
     const EaMc68000 &ea) {
     const EaMode mode = ea.mode;
     if (mode == M_ILLEGAL)
@@ -138,7 +138,7 @@ Error DisMc68000::decodeEffectiveAddr(
 }
 
 Error DisMc68000::decodeImplied(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     if (insn.insnCode() == 047162) { // STOP
         *_operands++ = '#';
         return decodeImmediateData(memory, insn, SZ_WORD);
@@ -149,7 +149,7 @@ Error DisMc68000::decodeImplied(
 // ORI, ANDI, SUBI, ADDI, EORI, CMPI
 // NEGX, CLR, NEG, NOT, TST
 Error DisMc68000::decodeDestSiz(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaMc68000 ea(insnCode);
     const uint8_t opc = (insnCode >> 9) & 7;
@@ -192,7 +192,7 @@ Error DisMc68000::decodeDestSiz(
 
 // LINK, UNLK
 Error DisMc68000::decodeAddrReg(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const RegName dest = RegMc68000::decodeAddrReg(insn.insnCode());
     if (insn.insnCode() & 010) { // UNLK
         outRegName(dest);
@@ -211,7 +211,7 @@ Error DisMc68000::decodeAddrReg(
 
 // DBcc, SWAP
 Error DisMc68000::decodeDataReg(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const RegName dest = RegMc68000::decodeDataReg(insn.insnCode());
     if ((insn.insnCode() >> 12) == 4) { // SWAP
         outRegName(dest);
@@ -236,7 +236,7 @@ Error DisMc68000::decodeDataReg(
 
 // MOVE USP
 Error DisMc68000::decodeMoveUsp(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const RegName areg = RegMc68000::decodeAddrReg(insn.insnCode());
     if (insn.insnCode() & 010) { // USP->An
         outRegName(REG_USP);
@@ -252,7 +252,7 @@ Error DisMc68000::decodeMoveUsp(
 
 // TRAP
 Error DisMc68000::decodeTrapVec(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     *_operands++ = '#';
     outConstant(static_cast<uint8_t>(insn.insnCode() & 017), 10);
     return setError(OK);
@@ -260,7 +260,7 @@ Error DisMc68000::decodeTrapVec(
 
 // NBCD, PEA, TAS
 Error DisMc68000::decodeDataDst(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const uint8_t opc = (insnCode >> 6) & 077;
     constexpr uint8_t NBCD = 040;
@@ -286,7 +286,7 @@ Error DisMc68000::decodeDataDst(
 // JSR, JMP, Scc,
 // ASR, ASL, LSR, LSL, ROXR, ROXL
 Error DisMc68000::decodeDestOpr(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const EaMc68000 ea(insn.insnCode());
     EaSize size = ea.size;
 
@@ -326,7 +326,7 @@ Error DisMc68000::decodeDestOpr(
 
 // EXT
 Error DisMc68000::decodeSignExt(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     insn.appendSize((insnCode & 0100) ? SZ_LONG : SZ_WORD, _regs);
     outRegName(RegMc68000::decodeDataReg(insnCode));
@@ -335,7 +335,7 @@ Error DisMc68000::decodeSignExt(
 
 // EXT_BRA: BRA, BSR, Bcc
 Error DisMc68000::decodeRelative(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const uint8_t val8 = static_cast<uint8_t>(insn.insnCode());
     Config::uintptr_t addr = insn.address() + 2;
     if (val8) {
@@ -398,7 +398,7 @@ void DisMc68000::outMoveMltRegs(RegName start, RegName last, char suffix) {
 
 // MOVEM
 Error DisMc68000::decodeMoveMlt(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaMc68000 ea(
         (insnCode & 0100) ? SZ_LONG : SZ_WORD, insnCode >> 3, insnCode);
@@ -431,7 +431,7 @@ Error DisMc68000::decodeMoveMlt(
 
 // MOVE fromSR, toSR, toCCR
 Error DisMc68000::decodeMoveSr(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const host::uint_t opc = (insnCode >> 8) & 017;
     constexpr host::uint_t toCCR = 4;
@@ -456,7 +456,7 @@ Error DisMc68000::decodeMoveSr(
 
 // MOVEQ
 Error DisMc68000::decodeMoveQic(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const uint8_t val8 = static_cast<uint8_t>(insnCode);
     *_operands++ = '#';
@@ -468,7 +468,7 @@ Error DisMc68000::decodeMoveQic(
 
 // MOVEP
 Error DisMc68000::decodeMovePer(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaMc68000 ea(
         (insnCode & 0100) ? SZ_LONG : SZ_WORD, M_DISP, insnCode);
@@ -489,7 +489,7 @@ Error DisMc68000::decodeMovePer(
 // AREG_LNG: LEA
 // AREG_SIZ: SUBA, CMPA, ADDA
 Error DisMc68000::decodeAregSiz(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     EaSize size = (insnCode & 0400) ? SZ_LONG : SZ_WORD;
     const EaMc68000 ea(size, insnCode >> 3, insnCode);
@@ -512,7 +512,7 @@ Error DisMc68000::decodeAregSiz(
 
 // NO_EXT: BTST, BCHG, BCLR, BSET, CHK, DIVU, DIVS, MULU, MULS
 Error DisMc68000::decodeDregDst(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const RegName dest = RegMc68000::decodeDataReg(insn.insnCode() >> 9);
     EaSize size;
@@ -556,7 +556,7 @@ static EaSize moveSize(host::uint_t moveSize) {
 
 // ADDQ, SUBQ
 Error DisMc68000::decodeDataQic(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaMc68000 ea(insnCode);
     uint8_t val = (insnCode >> 9) & 7;
@@ -573,7 +573,7 @@ Error DisMc68000::decodeDataQic(
 // DMEM_SIZ: OR, SUB, AND, ADD
 // DREG_SIZ: CMP, EOR
 Error DisMc68000::decodeDmemSiz(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaMc68000 ea(insnCode);
     const RegName dreg = RegMc68000::decodeDataReg(insnCode >> 9);
@@ -594,7 +594,7 @@ Error DisMc68000::decodeDmemSiz(
 
 // ASR, ASL, LSR, LSL, ROXR, ROXL, ROR, ROL
 Error DisMc68000::decodeDregRot(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const RegName dst = RegMc68000::decodeDataReg(insnCode);
     const EaSize size = EaSize((insnCode >> 6) & 3);
@@ -616,7 +616,7 @@ Error DisMc68000::decodeDregRot(
 // DMEM_OPR: SUBX, ADDX
 // CMPM_SIZ: CMPM
 Error DisMc68000::decodeDmemOpr(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const uint8_t opc = (insnCode >> 12);
     constexpr uint8_t SBCD = 010;
@@ -642,7 +642,7 @@ Error DisMc68000::decodeDmemOpr(
 
 // EXG
 Error DisMc68000::decodeRegsExg(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const uint8_t mode = (insnCode >> 3) & 031;
     if (mode == 010) {          // Dx,Dy
@@ -663,7 +663,7 @@ Error DisMc68000::decodeRegsExg(
 
 // NO_EXT: MOVE, MOVEA
 Error DisMc68000::decodeMoveOpr(
-    DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn) {
+    DisMemory<Config> &memory, InsnMc68000 &insn) {
     const Config::insn_t insnCode = insn.insnCode();
     const EaSize size = moveSize(insnCode >> 12);
     const EaMc68000 src(size, insnCode >> 3, insnCode);
@@ -682,7 +682,7 @@ Error DisMc68000::decodeMoveOpr(
 }
 
 Error DisMc68000::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnMc68000 insn(_insn);
     Config::insn_t insnCode;
     if (insn.readUint16(memory, insnCode)) return setError(NO_MEMORY);

--- a/src/dis_mc68000.h
+++ b/src/dis_mc68000.h
@@ -32,9 +32,9 @@ public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
     const char *listCpu() const override { return TableMc68000::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    Endian endian() const override { return Config::endian; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;

--- a/src/dis_mc68000.h
+++ b/src/dis_mc68000.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace mc68000 {
 
-class DisMc68000 : public Disassembler<target::uintptr_t> {
+class DisMc68000 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
@@ -46,63 +46,64 @@ private:
     void outEaSize(EaSize size);
 
     Error decodeImmediateData(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn,
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn,
         EaSize eaSize);
     Error decodeEffectiveAddr(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn,
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn,
         const EaMc68000 &ea);
 
     Error decodeImplied(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDestSiz(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeAddrReg(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDataReg(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeMoveUsp(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeTrapVec(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDataDst(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDestOpr(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeSignExt(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeRelative(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     void  decodeMoveMltRegList(
         uint16_t list, bool pop,
         void (DisMc68000::*outRegs)(RegName, RegName, char));
     void  outMoveMltRegs(RegName start, RegName last, char suffix);
     Error decodeMoveMlt(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeMoveSr(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeMoveQic(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeMovePer(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeAregSiz(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDregDst(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDataQic(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDmemSiz(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDregRot(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeDmemOpr(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeRegsExg(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
     Error decodeMoveOpr(
-        DisMemory<target::uintptr_t> &memory, InsnMc68000 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
 
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn &insn) override;
+        DisMemory<Config::uintptr_t> &memory,
+        Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace mc68000

--- a/src/dis_mc68000.h
+++ b/src/dis_mc68000.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace mc68000 {
 
-class DisMc68000 : public Disassembler<Config::uintptr_t> {
+class DisMc68000 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc68000.setCpu(cpu); }
     const char *listCpu() const override { return TableMc68000::listCpu(); }
-    Endian endian() const override { return Config::endian; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;
@@ -46,64 +43,38 @@ private:
     void outEaSize(EaSize size);
 
     Error decodeImmediateData(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn,
-        EaSize eaSize);
+        DisMemory<Config> &memory, InsnMc68000 &insn, EaSize eaSize);
     Error decodeEffectiveAddr(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn,
-        const EaMc68000 &ea);
+        DisMemory<Config> &memory, InsnMc68000 &insn, const EaMc68000 &ea);
 
-    Error decodeImplied(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDestSiz(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeAddrReg(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDataReg(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeMoveUsp(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeTrapVec(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDataDst(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDestOpr(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeSignExt(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeRelative(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
+    Error decodeImplied(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDestSiz(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeAddrReg(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDataReg(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeMoveUsp(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeTrapVec(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDataDst(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDestOpr(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeSignExt(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeRelative(DisMemory<Config> &memory, InsnMc68000 &insn);
     void  decodeMoveMltRegList(
         uint16_t list, bool pop,
         void (DisMc68000::*outRegs)(RegName, RegName, char));
     void  outMoveMltRegs(RegName start, RegName last, char suffix);
-    Error decodeMoveMlt(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeMoveSr(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeMoveQic(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeMovePer(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeAregSiz(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDregDst(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDataQic(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDmemSiz(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDregRot(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeDmemOpr(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeRegsExg(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
-    Error decodeMoveOpr(
-        DisMemory<Config::uintptr_t> &memory, InsnMc68000 &insn);
+    Error decodeMoveMlt(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeMoveSr(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeMoveQic(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeMovePer(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeAregSiz(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDregDst(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDataQic(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDmemSiz(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDregRot(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeDmemOpr(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeRegsExg(DisMemory<Config> &memory, InsnMc68000 &insn);
+    Error decodeMoveOpr(DisMemory<Config> &memory, InsnMc68000 &insn);
 
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory,
-        Insn<Config::uintptr_t> &insn) override;
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace mc68000

--- a/src/dis_mc6809.cpp
+++ b/src/dis_mc6809.cpp
@@ -25,7 +25,7 @@ void DisMc6809::outRegister(RegName regName) {
 }
 
 Error DisMc6809::decodeDirectPage(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t dir;
     if (insn.readByte(memory, dir)) return setError(NO_MEMORY);
     const char *label = lookup(dir);
@@ -39,7 +39,7 @@ Error DisMc6809::decodeDirectPage(
 }
 
 Error DisMc6809::decodeExtended(
-    DisMemory<Config::uintptr_t>& memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     Config::uintptr_t addr;
     if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
     const char *label = lookup(addr);
@@ -53,7 +53,7 @@ Error DisMc6809::decodeExtended(
 }
 
 Error DisMc6809::decodeIndexed(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t post;
     if (insn.readByte(memory, post)) return setError(NO_MEMORY);
     const uint8_t mode = post & 0x8F;
@@ -180,7 +180,7 @@ Error DisMc6809::decodeIndexed(
 }
 
 Error DisMc6809::decodeRelative(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     Config::ptrdiff_t delta;
     if (insn.oprSize() == SZ_BYTE) {
         uint8_t val;
@@ -202,7 +202,7 @@ Error DisMc6809::decodeRelative(
 }
 
 Error DisMc6809::decodeImmediate(
-    DisMemory<Config::uintptr_t>& memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     *_operands++ = '#';
     if (insn.oprSize() == SZ_BYTE) {
         uint8_t val;
@@ -239,7 +239,7 @@ Error DisMc6809::decodeImmediate(
 }
 
 Error DisMc6809::decodeStackOp(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t post;
     if (insn.readByte(memory, post)) return setError(NO_MEMORY);
     const bool push = (insn.insnCode() & 1) == 0;
@@ -255,7 +255,7 @@ Error DisMc6809::decodeStackOp(
 }
 
 Error DisMc6809::decodeRegisters(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t post;
     if (insn.readByte(memory, post)) return setError(NO_MEMORY);
     const RegName src = _regs.decodeRegName(post >> 4);
@@ -273,7 +273,7 @@ Error DisMc6809::decodeRegisters(
 }
 
 Error DisMc6809::decodeImmediatePlus(
-    DisMemory<Config::uintptr_t>& memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     *_operands++ = '#';
     uint8_t val;
     if (insn.readByte(memory, val)) return setError(NO_MEMORY);
@@ -288,7 +288,7 @@ Error DisMc6809::decodeImmediatePlus(
 }
 
 Error DisMc6809::decodeBitOperation(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t post;
     if (insn.readByte(memory, post)) return setError(NO_MEMORY);
     const RegName reg = _regs.decodeBitOpReg(post >> 6);
@@ -304,7 +304,7 @@ Error DisMc6809::decodeBitOperation(
 }
 
 Error DisMc6809::decodeTransferMemory(
-    DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn) {
+    DisMemory<Config> &memory, InsnMc6809 &insn) {
     uint8_t post;
     if (insn.readByte(memory, post)) return setError(NO_MEMORY);
     const RegName src = _regs.decodeTfmBaseReg(post >> 4);
@@ -323,7 +323,7 @@ Error DisMc6809::decodeTransferMemory(
 }
 
 Error DisMc6809::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnMc6809 insn(_insn);
     Config::opcode_t opCode;
     if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);

--- a/src/dis_mc6809.h
+++ b/src/dis_mc6809.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace mc6809 {
 
-class DisMc6809 : public Disassembler<Config::uintptr_t> {
+class DisMc6809 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6809::listCpu(); }
-    Endian endian() const override { return Config::endian; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;
@@ -44,31 +41,19 @@ private:
     void outRegister(RegName regName);
 
     // MC6809
-    Error decodeDirectPage(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeIndexed(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeExtended(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeRelative(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeImmediate(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeStackOp(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeRegisters(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
+    Error decodeDirectPage(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeIndexed(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeExtended(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeRelative(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeImmediate(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeStackOp(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeRegisters(DisMemory<Config> &memory, InsnMc6809 &insn);
     // HD6309
-    Error decodeImmediatePlus(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeBitOperation(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
-    Error decodeTransferMemory(
-        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
+    Error decodeImmediatePlus(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeBitOperation(DisMemory<Config> &memory, InsnMc6809 &insn);
+    Error decodeTransferMemory(DisMemory<Config> &memory, InsnMc6809 &insn);
 
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory,
-        Insn<Config::uintptr_t> &insn) override;
+    Error decode(DisMemory<Config> &memory,  Insn<Config> &insn) override;
 };
 
 } // namespace mc6809

--- a/src/dis_mc6809.h
+++ b/src/dis_mc6809.h
@@ -32,9 +32,9 @@ public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
     const char *listCpu() const override { return TableMc6809::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    Endian endian() const override { return Config::endian; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisMotoOperand _formatter;

--- a/src/dis_mc6809.h
+++ b/src/dis_mc6809.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace mc6809 {
 
-class DisMc6809 : public Disassembler<target::uintptr_t> {
+class DisMc6809 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableMc6809.setCpu(cpu); }
@@ -45,29 +45,30 @@ private:
 
     // MC6809
     Error decodeDirectPage(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeIndexed(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeExtended(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeRelative(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeImmediate(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeStackOp(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeRegisters(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     // HD6309
     Error decodeImmediatePlus(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeBitOperation(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
     Error decodeTransferMemory(
-        DisMemory<target::uintptr_t> &memory, InsnMc6809 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnMc6809 &insn);
 
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn &insn) override;
+        DisMemory<Config::uintptr_t> &memory,
+        Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace mc6809

--- a/src/dis_memory.h
+++ b/src/dis_memory.h
@@ -19,11 +19,13 @@
 
 namespace libasm {
 
-template<typename Addr>
+template<typename Conf>
 class DisMemory {
+    typedef typename Conf::uintptr_t addr_t;
+
 public:
     virtual bool hasNext() const = 0;
-    Addr address() const { return _address; }
+    addr_t address() const { return _address; }
     uint8_t readByte() {
         const uint8_t val = nextByte();
         _address++;
@@ -31,9 +33,9 @@ public:
     }
 
 protected:
-    Addr _address;
+    addr_t _address;
 
-    DisMemory(Addr address) : _address(address) {}
+    DisMemory(addr_t address) : _address(address) {}
     virtual uint8_t nextByte() = 0;
 };
 

--- a/src/dis_tms9900.cpp
+++ b/src/dis_tms9900.cpp
@@ -20,7 +20,7 @@
 namespace libasm {
 namespace tms9900 {
 
-void DisTms9900::outAddress(target::uintptr_t addr, bool relax) {
+void DisTms9900::outAddress(Config::uintptr_t addr, bool relax) {
     const char *label = lookup(addr);
     if (label) {
         outText(label);
@@ -30,7 +30,7 @@ void DisTms9900::outAddress(target::uintptr_t addr, bool relax) {
 }
 
 Error DisTms9900::decodeOperand(
-    DisMemory<target::uintptr_t> &memory, InsnTms9900 &insn, const host::uint_t opr) {
+    DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn, const host::uint_t opr) {
     const host::uint_t regno = opr & 0xf;
     const host::uint_t mode = (opr >> 4) & 0x3;
     if (mode == 1 || mode == 3) *_operands++ = '*';
@@ -54,7 +54,7 @@ Error DisTms9900::decodeOperand(
 }
 
 Error DisTms9900::decodeImmediate(
-    DisMemory<target::uintptr_t>& memory, InsnTms9900 &insn) {
+    DisMemory<Config::uintptr_t>& memory, InsnTms9900 &insn) {
     uint16_t val;
     if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
     outAddress(val);
@@ -64,15 +64,15 @@ Error DisTms9900::decodeImmediate(
 Error DisTms9900::decodeRelative(InsnTms9900 &insn) {
     int16_t delta = static_cast<int8_t>(insn.insnCode() & 0xff);
     delta <<= 1;
-    const target::uintptr_t addr = insn.address() + 2 + delta;
+    const Config::uintptr_t addr = insn.address() + 2 + delta;
     outAddress(addr, false);
     return setError(OK);
 }
 
 Error DisTms9900::decode(
-    DisMemory<target::uintptr_t> &memory, Insn &_insn) {
+    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
     InsnTms9900 insn(_insn);
-    target::insn_t insnCode;
+    Config::insn_t insnCode;
     if (insn.readUint16(memory, insnCode)) return setError(NO_MEMORY);
     insn.setInsnCode(insnCode);
     if (TableTms9900.searchInsnCode(insn)) {

--- a/src/dis_tms9900.cpp
+++ b/src/dis_tms9900.cpp
@@ -30,7 +30,7 @@ void DisTms9900::outAddress(Config::uintptr_t addr, bool relax) {
 }
 
 Error DisTms9900::decodeOperand(
-    DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn, const host::uint_t opr) {
+    DisMemory<Config> &memory, InsnTms9900 &insn, const host::uint_t opr) {
     const host::uint_t regno = opr & 0xf;
     const host::uint_t mode = (opr >> 4) & 0x3;
     if (mode == 1 || mode == 3) *_operands++ = '*';
@@ -54,7 +54,7 @@ Error DisTms9900::decodeOperand(
 }
 
 Error DisTms9900::decodeImmediate(
-    DisMemory<Config::uintptr_t>& memory, InsnTms9900 &insn) {
+    DisMemory<Config>& memory, InsnTms9900 &insn) {
     uint16_t val;
     if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
     outAddress(val);
@@ -70,7 +70,7 @@ Error DisTms9900::decodeRelative(InsnTms9900 &insn) {
 }
 
 Error DisTms9900::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnTms9900 insn(_insn);
     Config::insn_t insnCode;
     if (insn.readUint16(memory, insnCode)) return setError(NO_MEMORY);

--- a/src/dis_tms9900.h
+++ b/src/dis_tms9900.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace tms9900 {
 
-class DisTms9900 : public Disassembler<target::uintptr_t> {
+class DisTms9900 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
@@ -42,16 +42,17 @@ private:
 
     RegBase &getRegister() override { return _regs; }
 
-    void outAddress(target::uintptr_t addr, bool relax = true);
+    void outAddress(Config::uintptr_t addr, bool relax = true);
 
     Error decodeOperand(
-        DisMemory<target::uintptr_t> &memory, InsnTms9900 &insn,
+        DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn,
         host::uint_t opr);
     Error decodeImmediate(
-        DisMemory<target::uintptr_t> &memory, InsnTms9900 &insn);
+        DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn);
     Error decodeRelative(InsnTms9900 &insn);
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn& insn) override;
+        DisMemory<Config::uintptr_t> &memory,
+        Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace tms9900

--- a/src/dis_tms9900.h
+++ b/src/dis_tms9900.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
     const char *listCpu() const override { return TableTms9900::listCpu(); }
     Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;

--- a/src/dis_tms9900.h
+++ b/src/dis_tms9900.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace tms9900 {
 
-class DisTms9900 : public Disassembler<Config::uintptr_t> {
+class DisTms9900 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableTms9900.setCpu(cpu); }
     const char *listCpu() const override { return TableTms9900::listCpu(); }
-    Endian endian() const override { return ENDIAN_BIG; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;
@@ -45,14 +42,10 @@ private:
     void outAddress(Config::uintptr_t addr, bool relax = true);
 
     Error decodeOperand(
-        DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn,
-        host::uint_t opr);
-    Error decodeImmediate(
-        DisMemory<Config::uintptr_t> &memory, InsnTms9900 &insn);
+        DisMemory<Config> &memory, InsnTms9900 &insn, host::uint_t opr);
+    Error decodeImmediate(DisMemory<Config> &memory, InsnTms9900 &insn);
     Error decodeRelative(InsnTms9900 &insn);
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory,
-        Insn<Config::uintptr_t> &insn) override;
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace tms9900

--- a/src/dis_z80.cpp
+++ b/src/dis_z80.cpp
@@ -62,7 +62,7 @@ void DisZ80::outDataRegister(RegName regName) {
     }
 }
 
-void DisZ80::outConditionName(target::opcode_t cc, bool cc8) {
+void DisZ80::outConditionName(Config::opcode_t cc, bool cc8) {
     if (cc8) {
         _operands = _regs.outCc8Name(_operands, cc);
     } else {
@@ -71,7 +71,7 @@ void DisZ80::outConditionName(target::opcode_t cc, bool cc8) {
 }
 
 Error DisZ80::decodeInherent(InsnZ80 &insn) {
-    const target::opcode_t opc = insn.opCode();
+    const Config::opcode_t opc = insn.opCode();
     switch (insn.leftFormat()) {
     case A_REG:
         outRegister(REG_A);
@@ -199,7 +199,7 @@ Error DisZ80::decodeInherent(InsnZ80 &insn) {
 }
 
 Error DisZ80::decodeImmediate8(InsnZ80 &insn, uint8_t val) {
-    const target::opcode_t opc = insn.opCode();
+    const Config::opcode_t opc = insn.opCode();
     switch (insn.leftFormat()) {
     case A_REG:
         outRegister(REG_A);
@@ -221,7 +221,7 @@ Error DisZ80::decodeImmediate8(InsnZ80 &insn, uint8_t val) {
 }
 
 Error DisZ80::decodeImmediate16(InsnZ80 &insn, uint16_t val) {
-    const target::opcode_t opc = insn.opCode();
+    const Config::opcode_t opc = insn.opCode();
     switch (insn.leftFormat()) {
     case REG_16:
         outRegister(RegZ80::decodePointerReg((opc >> 4) & 3));
@@ -237,8 +237,8 @@ Error DisZ80::decodeImmediate16(InsnZ80 &insn, uint16_t val) {
     return setError(OK);
 }
 
-Error DisZ80::decodeDirect(InsnZ80 &insn, target::uintptr_t addr) {
-    const target::opcode_t opc = insn.opCode();
+Error DisZ80::decodeDirect(InsnZ80 &insn, Config::uintptr_t addr) {
+    const Config::opcode_t opc = insn.opCode();
     RegName regName;
     switch (insn.leftFormat()) {
     case ADDR_16:
@@ -324,17 +324,17 @@ Error DisZ80::decodeIoaddr(InsnZ80 &insn, uint8_t ioaddr) {
 
 Error DisZ80::decodeRelative(InsnZ80 &insn, int8_t delta) {
     if (insn.leftFormat() == COND_4) {
-        const target::opcode_t opc = insn.opCode();
+        const Config::opcode_t opc = insn.opCode();
         outConditionName((opc >> 3) & 3, false);
         *_operands++ = ',';
     }
-    const target::uintptr_t addr = insn.address() + 2 + delta;
+    const Config::uintptr_t addr = insn.address() + 2 + delta;
     outAddress(addr, false);
     return setError(OK);
 }
 
 Error DisZ80::decodeIndexed(InsnZ80 &insn, int8_t offset) {
-    const target::opcode_t opc = insn.opCode();
+    const Config::opcode_t opc = insn.opCode();
     RegName regName;
     switch (insn.leftFormat()) {
     case IX_OFF:
@@ -378,7 +378,7 @@ Error DisZ80::decodeIndexedImmediate8(
 }
 
 Error DisZ80::decodeIndexedBitOp(
-    InsnZ80 &insn, int8_t offset, target::opcode_t opCode) {
+    InsnZ80 &insn, int8_t offset, Config::opcode_t opCode) {
     InsnZ80 ixBit(insn);
     ixBit.setInsnCode(insn.opCode(), opCode);
     if (TableZ80.searchInsnCode(ixBit)) 
@@ -401,13 +401,13 @@ Error DisZ80::decodeIndexedBitOp(
 }
 
 Error DisZ80::decode(
-    DisMemory<target::uintptr_t> &memory, Insn &_insn) {
+    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
     InsnZ80 insn(_insn);
-    target::opcode_t opCode;
+    Config::opcode_t opCode;
     if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
     insn.setInsnCode(0, opCode);
     if (TableZ80.isZ80() && TableZ80::isPrefixCode(opCode)) {
-        const target::opcode_t prefix = opCode;
+        const Config::opcode_t prefix = opCode;
         if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
         insn.setInsnCode(prefix, opCode);
     }

--- a/src/dis_z80.cpp
+++ b/src/dis_z80.cpp
@@ -401,7 +401,7 @@ Error DisZ80::decodeIndexedBitOp(
 }
 
 Error DisZ80::decode(
-    DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t> &_insn) {
+    DisMemory<Config> &memory, Insn<Config> &_insn) {
     InsnZ80 insn(_insn);
     Config::opcode_t opCode;
     if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);

--- a/src/dis_z80.h
+++ b/src/dis_z80.h
@@ -33,8 +33,8 @@ public:
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
     const char *listCpu() const override { return TableZ80::listCpu(); }
     Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Entry::code_max; }
-    host::uint_t maxName() const override { return Entry::name_max; }
+    host::uint_t maxBytes() const override { return Config::code_max; }
+    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;

--- a/src/dis_z80.h
+++ b/src/dis_z80.h
@@ -27,14 +27,11 @@
 namespace libasm {
 namespace z80 {
 
-class DisZ80 : public Disassembler<Config::uintptr_t> {
+class DisZ80 : public Disassembler<Config> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
     const char *listCpu() const override { return TableZ80::listCpu(); }
-    Endian endian() const override { return ENDIAN_LITTLE; }
-    host::uint_t maxBytes() const override { return Config::code_max; }
-    host::uint_t maxName() const override { return Config::name_max; }
 
 private:
     DisIntelOperand _formatter;
@@ -49,8 +46,7 @@ private:
     void outDataRegister(RegName regName);
     void outConditionName(Config::opcode_t cc, bool cc8 = true);
 
-    Error decodeOperand(
-        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t>& insn);
+    Error decodeOperand(DisMemory<Config> &memory, Insn<Config>& insn);
 
     Error decodeInherent(InsnZ80 &insn);
     Error decodeImmediate8(InsnZ80 &insn, uint8_t val);
@@ -64,9 +60,7 @@ private:
     Error decodeIndexedBitOp(
         InsnZ80 &insn, int8_t offset, Config::opcode_t opCode);
 
-    Error decode(
-        DisMemory<Config::uintptr_t> &memory,
-        Insn<Config::uintptr_t> &insn) override;
+    Error decode(DisMemory<Config> &memory, Insn<Config> &insn) override;
 };
 
 } // namespace z80

--- a/src/dis_z80.h
+++ b/src/dis_z80.h
@@ -27,7 +27,7 @@
 namespace libasm {
 namespace z80 {
 
-class DisZ80 : public Disassembler<target::uintptr_t> {
+class DisZ80 : public Disassembler<Config::uintptr_t> {
 public:
     DisOperand &getFormatter() override { return _formatter; }
     bool setCpu(const char *cpu) override { return TableZ80.setCpu(cpu); }
@@ -47,25 +47,26 @@ private:
     void outRegister(RegName regName);
     void outPointer(RegName regName);
     void outDataRegister(RegName regName);
-    void outConditionName(target::opcode_t cc, bool cc8 = true);
+    void outConditionName(Config::opcode_t cc, bool cc8 = true);
 
     Error decodeOperand(
-        DisMemory<target::uintptr_t> &memory, Insn& insn);
+        DisMemory<Config::uintptr_t> &memory, Insn<Config::uintptr_t>& insn);
 
     Error decodeInherent(InsnZ80 &insn);
     Error decodeImmediate8(InsnZ80 &insn, uint8_t val);
     Error decodeImmediate16(InsnZ80 &insn, uint16_t val);
-    Error decodeDirect(InsnZ80 &insn, target::uintptr_t addr);
+    Error decodeDirect(InsnZ80 &insn, Config::uintptr_t addr);
     Error decodeIoaddr(InsnZ80 &insn, uint8_t ioaddr);
     Error decodeRelative(InsnZ80 &insn, int8_t delta);
     Error decodeIndexed(InsnZ80 &insn, int8_t offset);
     Error decodeIndexedImmediate8(
         InsnZ80 &insn, int8_t offset, uint8_t val);
     Error decodeIndexedBitOp(
-        InsnZ80 &insn, int8_t offset, target::opcode_t opCode);
+        InsnZ80 &insn, int8_t offset, Config::opcode_t opCode);
 
     Error decode(
-        DisMemory<target::uintptr_t> &memory, Insn &insn) override;
+        DisMemory<Config::uintptr_t> &memory,
+        Insn<Config::uintptr_t> &insn) override;
 };
 
 } // namespace z80

--- a/src/entry_i8080.h
+++ b/src/entry_i8080.h
@@ -44,8 +44,6 @@ enum InsnFormat : host::uint_t {
 struct Entry {
     const Config::insn_t insnCode;
     const host::uint_t flags;
-    static constexpr host::uint_t code_max = 3;
-    static constexpr host::uint_t name_max = 4;
     const char *name;
 
     static inline InsnFormat _insnFormat(host::uint_t flags) {

--- a/src/entry_i8080.h
+++ b/src/entry_i8080.h
@@ -42,7 +42,7 @@ enum InsnFormat : host::uint_t {
 };
 
 struct Entry {
-    const target::insn_t insnCode;
+    const Config::insn_t insnCode;
     const host::uint_t flags;
     static constexpr host::uint_t code_max = 3;
     static constexpr host::uint_t name_max = 4;

--- a/src/entry_m6502.h
+++ b/src/entry_m6502.h
@@ -22,15 +22,6 @@
 namespace libasm {
 namespace m6502 {
 
-enum CpuType : host::uint_t {
-    M6502,
-    W65SC02,
-    R65C02BIT,
-    R65C02,
-    W65C02S,
-    W65C816,
-};
-
 enum AddrMode : host::uint_t {
     // M6502
     IMPL,                // Implied
@@ -68,8 +59,6 @@ struct Entry {
     const uint8_t insnCode;
     const host::uint_t flags;
     const char *name;
-    static constexpr host::uint_t code_max = 4;
-    static constexpr host::uint_t name_max = 4;
 
     static inline CpuType _cpuType(host::uint_t flags) {
         return CpuType((flags >> cputype_gp) & cputype_gm);

--- a/src/entry_mc6800.h
+++ b/src/entry_mc6800.h
@@ -46,7 +46,7 @@ enum OprSize : host::uint_t {
 };
 
 struct Entry {
-    const target::opcode_t opc;
+    const Config::opcode_t opc;
     const host::uint_t flags;
     const char *name;
     static constexpr host::uint_t code_max = 3;

--- a/src/entry_mc6800.h
+++ b/src/entry_mc6800.h
@@ -49,8 +49,6 @@ struct Entry {
     const Config::opcode_t opc;
     const host::uint_t flags;
     const char *name;
-    static constexpr host::uint_t code_max = 3;
-    static constexpr host::uint_t name_max = 3;
 
     static inline AddrMode _addrMode(host::uint_t flags) {
         return AddrMode(flags & addrMode_gm);

--- a/src/entry_mc68000.h
+++ b/src/entry_mc68000.h
@@ -63,7 +63,7 @@ enum ExtWord : host::uint_t {
 };
 
 struct Entry {
-    const target::insn_t insnCode;
+    const Config::insn_t insnCode;
     const host::uint_t flags;
     const char *name;
     static constexpr host::uint_t code_max = 10;

--- a/src/entry_mc68000.h
+++ b/src/entry_mc68000.h
@@ -66,8 +66,6 @@ struct Entry {
     const Config::insn_t insnCode;
     const host::uint_t flags;
     const char *name;
-    static constexpr host::uint_t code_max = 10;
-    static constexpr host::uint_t name_max = 7;
 
     static inline InsnFormat _insnFormat(host::uint_t flags) {
         return InsnFormat((flags >> insnFmt_gp) & insnFmt_gm);

--- a/src/entry_mc6809.h
+++ b/src/entry_mc6809.h
@@ -54,7 +54,7 @@ enum AddrMode : host::uint_t {
 };
 
 struct Entry {
-    const target::opcode_t opc;
+    const Config::opcode_t opc;
     const host::uint_t flags;
     const char *name;
     static constexpr host::uint_t code_max = 5;

--- a/src/entry_mc6809.h
+++ b/src/entry_mc6809.h
@@ -22,11 +22,6 @@
 namespace libasm {
 namespace mc6809 {
 
-enum CpuType : host::uint_t {
-    MC6809,
-    HD6309,
-};
-
 enum OprSize : host::uint_t {
     SZ_NONE = 0,
     SZ_BYTE = 1,                // 8 bit operation
@@ -57,8 +52,6 @@ struct Entry {
     const Config::opcode_t opc;
     const host::uint_t flags;
     const char *name;
-    static constexpr host::uint_t code_max = 5;
-    static constexpr host::uint_t name_max = 6;
 
     static inline CpuType _cpuType(host::uint_t flags) {
         return (flags & hd6309_bm) == 0 ? MC6809 : HD6309;

--- a/src/entry_tms9900.h
+++ b/src/entry_tms9900.h
@@ -22,11 +22,6 @@
 namespace libasm {
 namespace tms9900 {
 
-enum CpuType : host::uint_t {
-    TMS9900,
-    TMS9995,
-};
-
 enum AddrMode : host::uint_t {
     INH,                        // ---- ---- ---- ----
     IMM,                        // ---- ---- ---- ---- + nnnn
@@ -45,8 +40,6 @@ enum AddrMode : host::uint_t {
 struct Entry {
     const Config::insn_t insnCode;
     const host::uint_t flags;
-    static constexpr host::uint_t code_max = 6;
-    static constexpr host::uint_t name_max = 4;
     const char *name;
 
     static inline CpuType _cpuType(host::uint_t flags) {

--- a/src/entry_tms9900.h
+++ b/src/entry_tms9900.h
@@ -43,7 +43,7 @@ enum AddrMode : host::uint_t {
 };
 
 struct Entry {
-    const target::insn_t insnCode;
+    const Config::insn_t insnCode;
     const host::uint_t flags;
     static constexpr host::uint_t code_max = 6;
     static constexpr host::uint_t name_max = 4;

--- a/src/entry_z80.h
+++ b/src/entry_z80.h
@@ -93,7 +93,7 @@ enum OprFormat : host::uint_t {
 };
 
 struct Entry {
-    const target::opcode_t opc;
+    const Config::opcode_t opc;
     const host::uint_t flags1;
     const host::uint_t flags2;
     const char *name;

--- a/src/entry_z80.h
+++ b/src/entry_z80.h
@@ -22,11 +22,6 @@
 namespace libasm {
 namespace z80 {
 
-enum CpuType : host::uint_t {
-    Z80,
-    I8080,
-};
-
 enum OprSize : host::uint_t {
     SZ_NONE,                    // unknown
     SZ_BYTE = 1,
@@ -97,8 +92,6 @@ struct Entry {
     const host::uint_t flags1;
     const host::uint_t flags2;
     const char *name;
-    static constexpr host::uint_t code_max = 4;
-    static constexpr host::uint_t name_max = 4;
 
     static inline InsnFormat _insnFormat(host::uint_t flags1) {
         return InsnFormat(flags1 & insnFormat_mask);

--- a/src/insn_base.h
+++ b/src/insn_base.h
@@ -25,11 +25,6 @@
 
 namespace libasm {
 
-enum Endian {
-    ENDIAN_BIG,
-    ENDIAN_LITTLE,
-};
-
 template<typename Addr>
 class Insn {
 public:

--- a/src/insn_i8080.h
+++ b/src/insn_i8080.h
@@ -23,25 +23,25 @@
 namespace libasm {
 namespace i8080 {
 
-class InsnI8080 : public InsnBase<ENDIAN_LITTLE> {
+class InsnI8080 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
 public:
-    InsnI8080(Insn& insn) : InsnBase(insn) {}
+    InsnI8080(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     InsnFormat insnFormat() const { return Entry::_insnFormat(_flags); }
 
     void setFlags(host::uint_t flags) { _flags = flags; }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    void embed(target::opcode_t data) {
+    void embed(Config::opcode_t data) {
         _insnCode |= data;
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
 };
 

--- a/src/insn_i8080.h
+++ b/src/insn_i8080.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace i8080 {
 
-class InsnI8080 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnI8080 : public InsnBase<Config> {
 public:
-    InsnI8080(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnI8080(Insn<Config> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     InsnFormat insnFormat() const { return Entry::_insnFormat(_flags); }

--- a/src/insn_i8080.h
+++ b/src/insn_i8080.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace i8080 {
 
-class InsnI8080 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
+class InsnI8080 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnI8080(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_m6502.h
+++ b/src/insn_m6502.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace m6502 {
 
-class InsnM6502 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
+class InsnM6502 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnM6502(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_m6502.h
+++ b/src/insn_m6502.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace m6502 {
 
-class InsnM6502 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnM6502 : public InsnBase<Config> {
 public:
-    InsnM6502(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnM6502(Insn<Config> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     bool supported(CpuType cpuType) const {

--- a/src/insn_m6502.h
+++ b/src/insn_m6502.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace m6502 {
 
-class InsnM6502 : public InsnBase<ENDIAN_LITTLE> {
+class InsnM6502 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
 public:
-    InsnM6502(Insn &insn) : InsnBase(insn) {}
+    InsnM6502(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     bool supported(CpuType cpuType) const {
@@ -45,8 +45,8 @@ public:
         _flags = Entry::_flags(Entry::_cpuType(_flags), addrMode);
     }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
     void emitInsn() {
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
 };
 

--- a/src/insn_mc6800.h
+++ b/src/insn_mc6800.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace mc6800 {
 
-class InsnMc6800 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnMc6800 : public InsnBase<Config> {
 public:
-    InsnMc6800(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnMc6800(Insn<Config> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     InsnAdjust insnAdjust() const { return Entry::_insnAdjust(_flags); }

--- a/src/insn_mc6800.h
+++ b/src/insn_mc6800.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace mc6800 {
 
-class InsnMc6800 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
+class InsnMc6800 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnMc6800(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_mc6800.h
+++ b/src/insn_mc6800.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace mc6800 {
 
-class InsnMc6800 : public InsnBase<ENDIAN_BIG> {
+class InsnMc6800 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
 public:
-    InsnMc6800(Insn &insn) : InsnBase(insn) {}
+    InsnMc6800(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     InsnAdjust insnAdjust() const { return Entry::_insnAdjust(_flags); }
@@ -40,11 +40,11 @@ public:
             addrMode, Entry::_insnAdjust(_flags), Entry::_oprSize(_flags));
     }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    void embed(target::opcode_t data) {
+    void embed(Config::opcode_t data) {
         _insnCode |= data;
     }
     void emitInsn() {
@@ -52,7 +52,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
 };
 

--- a/src/insn_mc68000.h
+++ b/src/insn_mc68000.h
@@ -24,9 +24,9 @@
 namespace libasm {
 namespace mc68000 {
 
-class InsnMc68000 : public InsnBase<ENDIAN_BIG> {
+class InsnMc68000 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
 public:
-    InsnMc68000(Insn &insn) : InsnBase(insn) {}
+    InsnMc68000(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     InsnFormat insnFormat() const { return Entry::_insnFormat(_flags); }
 
@@ -34,11 +34,11 @@ public:
         _flags = flags;
     }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    target::insn_t embed(target::insn_t data, host::uint_t gp = 0) {
+    Config::insn_t embed(Config::insn_t data, host::uint_t gp = 0) {
         return (_insnCode |= (data << gp));
     }
 
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
     EaSize _size;
 

--- a/src/insn_mc68000.h
+++ b/src/insn_mc68000.h
@@ -24,9 +24,9 @@
 namespace libasm {
 namespace mc68000 {
 
-class InsnMc68000 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnMc68000 : public InsnBase<Config> {
 public:
-    InsnMc68000(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnMc68000(Insn<Config> &insn) : InsnBase(insn) {}
 
     InsnFormat insnFormat() const { return Entry::_insnFormat(_flags); }
 

--- a/src/insn_mc68000.h
+++ b/src/insn_mc68000.h
@@ -24,7 +24,7 @@
 namespace libasm {
 namespace mc68000 {
 
-class InsnMc68000 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
+class InsnMc68000 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnMc68000(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_mc6809.h
+++ b/src/insn_mc6809.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace mc6809 {
 
-class InsnMc6809 : public InsnBase<ENDIAN_BIG> {
+class InsnMc6809 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
 public:
-    InsnMc6809(Insn &insn) : InsnBase(insn) {}
+    InsnMc6809(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     OprSize oprSize() const { return Entry::_oprSize(_flags); }
@@ -42,19 +42,19 @@ public:
             addrMode);
     }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    void setInsnCode(target::opcode_t prefixCode, target::opcode_t opCode) {
-        _insnCode = (static_cast<target::insn_t>(prefixCode) << 8) | opCode;
+    void setInsnCode(Config::opcode_t prefixCode, Config::opcode_t opCode) {
+        _insnCode = (static_cast<Config::insn_t>(prefixCode) << 8) | opCode;
     }
     bool hasPrefix() const { return prefixCode() != 0; }
-    target::opcode_t prefixCode() const {
-        return static_cast<target::opcode_t>(_insnCode >> 8);
+    Config::opcode_t prefixCode() const {
+        return static_cast<Config::opcode_t>(_insnCode >> 8);
     }
-    target::opcode_t opCode() const {
-        return static_cast<target::opcode_t>(_insnCode);
+    Config::opcode_t opCode() const {
+        return static_cast<Config::opcode_t>(_insnCode);
     }
 
     void emitInsn() {
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
 };
 

--- a/src/insn_mc6809.h
+++ b/src/insn_mc6809.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace mc6809 {
 
-class InsnMc6809 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
+class InsnMc6809 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnMc6809(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_mc6809.h
+++ b/src/insn_mc6809.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace mc6809 {
 
-class InsnMc6809 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnMc6809 : public InsnBase<Config> {
 public:
-    InsnMc6809(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnMc6809(Insn<Config> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     OprSize oprSize() const { return Entry::_oprSize(_flags); }

--- a/src/insn_tms9900.h
+++ b/src/insn_tms9900.h
@@ -23,20 +23,20 @@
 namespace libasm {
 namespace tms9900 {
 
-class InsnTms9900 : public InsnBase<ENDIAN_BIG> {
+class InsnTms9900 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
 public:
-    InsnTms9900(Insn &insn) : InsnBase(insn) {}
+    InsnTms9900(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     bool is9995() const { return Entry::_cpuType(_flags) == TMS9995; }
 
     void setFlags(host::uint_t flags) { _flags = flags; }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    void embed(target::opcode_t data) {
+    void embed(Config::opcode_t data) {
         _insnCode |= data;
     }
 
@@ -51,7 +51,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags;
 
     void emitUint16(uint16_t val, host::uint_t pos) {

--- a/src/insn_tms9900.h
+++ b/src/insn_tms9900.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace tms9900 {
 
-class InsnTms9900 : public InsnBase<ENDIAN_BIG, Config::uintptr_t> {
+class InsnTms9900 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnTms9900(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
 

--- a/src/insn_tms9900.h
+++ b/src/insn_tms9900.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace tms9900 {
 
-class InsnTms9900 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnTms9900 : public InsnBase<Config> {
 public:
-    InsnTms9900(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnTms9900(Insn<Config> &insn) : InsnBase(insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     bool is9995() const { return Entry::_cpuType(_flags) == TMS9995; }

--- a/src/insn_z80.h
+++ b/src/insn_z80.h
@@ -23,7 +23,7 @@
 namespace libasm {
 namespace z80 {
 
-class InsnZ80 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
+class InsnZ80 : public InsnBase<Config::endian, Config::uintptr_t> {
 public:
     InsnZ80(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
     InsnZ80(InsnZ80 &other) : InsnBase(other._insn) {}

--- a/src/insn_z80.h
+++ b/src/insn_z80.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace z80 {
 
-class InsnZ80 : public InsnBase<Config::endian, Config::uintptr_t> {
+class InsnZ80 : public InsnBase<Config> {
 public:
-    InsnZ80(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
+    InsnZ80(Insn<Config> &insn) : InsnBase(insn) {}
     InsnZ80(InsnZ80 &other) : InsnBase(other._insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags2); }

--- a/src/insn_z80.h
+++ b/src/insn_z80.h
@@ -23,9 +23,9 @@
 namespace libasm {
 namespace z80 {
 
-class InsnZ80 : public InsnBase<ENDIAN_LITTLE> {
+class InsnZ80 : public InsnBase<ENDIAN_LITTLE, Config::uintptr_t> {
 public:
-    InsnZ80(Insn &insn) : InsnBase(insn) {}
+    InsnZ80(Insn<Config::uintptr_t> &insn) : InsnBase(insn) {}
     InsnZ80(InsnZ80 &other) : InsnBase(other._insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags2); }
@@ -42,22 +42,22 @@ public:
         _flags2 = other._flags2;
     }
 
-    target::insn_t insnCode() const { return _insnCode; }
-    void setInsnCode(target::insn_t insnCode) {
+    Config::insn_t insnCode() const { return _insnCode; }
+    void setInsnCode(Config::insn_t insnCode) {
         _insnCode = insnCode;
     }
-    void embed(target::opcode_t data) {
+    void embed(Config::opcode_t data) {
         _insnCode |= data;
     }
-    void setInsnCode(target::opcode_t prefixCode, target::opcode_t opCode) {
-        _insnCode = (static_cast<target::insn_t>(prefixCode) << 8) | opCode;
+    void setInsnCode(Config::opcode_t prefixCode, Config::opcode_t opCode) {
+        _insnCode = (static_cast<Config::insn_t>(prefixCode) << 8) | opCode;
     }
     bool hasPrefix() const { return prefixCode() != 0; }
-    target::opcode_t prefixCode() const {
-        return static_cast<target::opcode_t>(_insnCode >> 8);
+    Config::opcode_t prefixCode() const {
+        return static_cast<Config::opcode_t>(_insnCode >> 8);
     }
-    target::opcode_t opCode() const {
-        return static_cast<target::opcode_t>(_insnCode);
+    Config::opcode_t opCode() const {
+        return static_cast<Config::opcode_t>(_insnCode);
     }
 
     void emitInsn() {
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-    target::insn_t _insnCode;
+    Config::insn_t _insnCode;
     host::uint_t _flags1;
     host::uint_t _flags2;
 };

--- a/src/reg_mc68000.cpp
+++ b/src/reg_mc68000.cpp
@@ -89,7 +89,7 @@ bool RegMc68000::isADreg(RegName reg) {
     return isAreg(reg) || isDreg(reg);
 }
 
-target::insn_t RegMc68000::encodeRegNo(RegName reg) {
+Config::insn_t RegMc68000::encodeRegNo(RegName reg) {
     return isDreg(reg)
         ? char(reg) - char(REG_D0)
         : char(reg) - char(REG_A0);
@@ -147,12 +147,12 @@ static EaMode parseEaMode(host::uint_t mode, host::uint_t regno) {
     return EaMode(mode);
 }
 
-target::insn_t EaMc68000::encodeMode(EaMode mode) {
+Config::insn_t EaMc68000::encodeMode(EaMode mode) {
     const host::uint_t m = host::uint_t(mode);
     return m >= 8 ? 7 : m;
 }
 
-target::insn_t EaMc68000::encodeRegNo(EaMode mode, RegName regName) {
+Config::insn_t EaMc68000::encodeRegNo(EaMode mode, RegName regName) {
     const host::uint_t m = host::uint_t(mode);
     if (m < 8) return RegMc68000::encodeRegNo(regName);
     if (m < 16) return m - 8;
@@ -216,7 +216,7 @@ static RegName encodeRegName(EaMode mode, host::uint_t regno) {
     }
 }
 
-EaMc68000::EaMc68000(target::insn_t insnCode) {
+EaMc68000::EaMc68000(Config::insn_t insnCode) {
     const host::uint_t regno = insnCode & 7;
     size = EaSize((insnCode >> 6) & 3);
     mode = parseEaMode((insnCode >> 3) & 7, regno);

--- a/src/reg_mc68000.h
+++ b/src/reg_mc68000.h
@@ -64,7 +64,7 @@ public:
     static bool isDreg(RegName reg);
     static bool isAreg(RegName reg);
     static bool isADreg(RegName reg);
-    static target::insn_t encodeRegNo(RegName reg);
+    static Config::insn_t encodeRegNo(RegName reg);
     static host::uint_t encodeRegPos(RegName reg);
     static RegName decodeDataReg(host::uint_t regno);
     static RegName decodeAddrReg(host::uint_t regno);
@@ -100,7 +100,7 @@ enum EaMode : host::uint_t {
 #define CAT_ALTERABLE 8
 
 struct EaMc68000 {
-    EaMc68000(target::insn_t insnCode);
+    EaMc68000(Config::insn_t insnCode);
     EaMc68000(EaSize size, host::uint_t mode, host::uint_t regno);
     EaMc68000(EaSize size, EaMode mode, host::uint_t regno);
 
@@ -108,8 +108,8 @@ struct EaMc68000 {
         return satisfy(mode, categories);
     }
     static bool satisfy(EaMode mode, host::uint_t categories);
-    static target::insn_t encodeMode(EaMode mode);
-    static target::insn_t encodeRegNo(EaMode mode, RegName regName);
+    static Config::insn_t encodeMode(EaMode mode);
+    static Config::insn_t encodeRegNo(EaMode mode, RegName regName);
     static const char *eaCategory(EaMode mode);
 
     EaSize size;

--- a/src/reg_mc6809.cpp
+++ b/src/reg_mc6809.cpp
@@ -140,7 +140,7 @@ static RegName decodeRegNumber(
     return entry < end ? RegName(pgm_read_byte(entry)) : REG_UNDEF;
 }
 
-RegName RegMc6809::getStackReg(host::uint_t bit, target::insn_t insnCode) {
+RegName RegMc6809::getStackReg(host::uint_t bit, Config::insn_t insnCode) {
     const RegName *table = (insnCode & 2) == 0
         ? &STACK_S_REGS[0] : &STACK_U_REGS[0];
     return RegName(pgm_read_byte(&table[bit]));

--- a/src/reg_mc6809.h
+++ b/src/reg_mc6809.h
@@ -60,7 +60,7 @@ public:
     char *outRegName(char *out, const RegName regName) const;
     char *outCCRBits(char *out, uint8_t val) const;
 
-    static RegName getStackReg(host::uint_t bit, target::insn_t insnCode);
+    static RegName getStackReg(host::uint_t bit, Config::insn_t insnCode);
     bool compareRegName(const char *line, RegName regName) const;
     host::uint_t regNameLen(RegName regName) const;
 

--- a/src/reg_z80.cpp
+++ b/src/reg_z80.cpp
@@ -154,12 +154,12 @@ bool RegZ80::compareCcName(const char *line, CcName ccName) const {
     return !isalpha(*line);
 }
 
-char *RegZ80::outCc4Name(char *out, const target::opcode_t cc4) const {
+char *RegZ80::outCc4Name(char *out, const Config::opcode_t cc4) const {
     const CcName cc = CcName(pgm_read_byte(&CC8_NAMES[cc4 & 3]));
     return outCcName(out, cc);
 }
 
-char *RegZ80::outCc8Name(char *out, const target::opcode_t cc8) const {
+char *RegZ80::outCc8Name(char *out, const Config::opcode_t cc8) const {
     const CcName cc = CcName(pgm_read_byte(&CC8_NAMES[cc8 & 7]));
     return outCcName(out, cc);
 }
@@ -249,7 +249,7 @@ host::int_t RegZ80::encodeIndirectBase(RegName regName) {
 }
 
 void RegZ80::encodeIndexReg(InsnZ80 &insn, RegName ixReg) {
-    const target::opcode_t prefix =
+    const Config::opcode_t prefix =
         (ixReg == REG_IX) ? TableZ80::PREFIX_IX : TableZ80::PREFIX_IY;
     insn.setInsnCode(prefix, insn.opCode());
 }
@@ -282,7 +282,7 @@ RegName RegZ80::decodeIndirectBase(uint8_t regNum) {
 }
 
 RegName RegZ80::decodeIndexReg(const InsnZ80 &insn) {
-    const target::opcode_t prefix = insn.prefixCode();
+    const Config::opcode_t prefix = insn.prefixCode();
     if (prefix == TableZ80::PREFIX_IX) return REG_IX;
     if (prefix == TableZ80::PREFIX_IY) return REG_IY;
     return REG_UNDEF;

--- a/src/reg_z80.h
+++ b/src/reg_z80.h
@@ -84,8 +84,8 @@ public:
     static RegName decodeDataReg(uint8_t regNum);
 
     char *outRegName(char *out, const RegName regName) const;
-    char *outCc4Name(char *out, target::opcode_t cc4) const;
-    char *outCc8Name(char *out, target::opcode_t cc8) const;
+    char *outCc4Name(char *out, Config::opcode_t cc4) const;
+    char *outCc8Name(char *out, Config::opcode_t cc8) const;
 
 private:
     RegName parseRegName(

--- a/src/str_memory.h
+++ b/src/str_memory.h
@@ -23,11 +23,11 @@
 
 namespace libasm {
 
-template<typename Addr>
-class StrMemory : public DisMemory<Addr> {
+template<typename Conf>
+class StrMemory : public DisMemory<Conf> {
 public:
-    StrMemory(Addr addr, const char *line)
-        : DisMemory<Addr>(addr), _next(line) {
+    StrMemory(typename Conf::uintptr_t addr, const char *line)
+        : DisMemory<Conf>(addr), _next(line) {
         skipSpaces();
     }
     

--- a/src/str_memory.h
+++ b/src/str_memory.h
@@ -27,7 +27,7 @@ template<typename Addr>
 class StrMemory : public DisMemory<Addr> {
 public:
     StrMemory(Addr addr, const char *line)
-        : DisMemory(addr), _next(line) {
+        : DisMemory<Addr>(addr), _next(line) {
         skipSpaces();
     }
     

--- a/src/str_memory.h
+++ b/src/str_memory.h
@@ -23,9 +23,10 @@
 
 namespace libasm {
 
-class StrMemory : public DisMemory<target::uintptr_t> {
+template<typename Addr>
+class StrMemory : public DisMemory<Addr> {
 public:
-    StrMemory(target::uintptr_t addr, const char *line)
+    StrMemory(Addr addr, const char *line)
         : DisMemory(addr), _next(line) {
         skipSpaces();
     }

--- a/src/table_i8080.cpp
+++ b/src/table_i8080.cpp
@@ -157,7 +157,7 @@ Error TableI8080::searchInsnCode(InsnI8080 &insn) const {
     const Entry *entry = searchEntry(insnCode, ARRAY_RANGE(TABLE_I8080));
     if (!entry) return UNKNOWN_INSTRUCTION;
     insn.setFlags(pgm_read_byte(&entry->flags));
-    char name[Entry::name_max + 1];
+    char name[Config::name_max + 1];
     pgm_strncpy(name, entry->name, sizeof(name));
     insn.setName(name);
     return OK;

--- a/src/table_i8080.cpp
+++ b/src/table_i8080.cpp
@@ -121,10 +121,10 @@ static const Entry *searchEntry(
 }
 
 static const Entry *searchEntry(
-    const target::insn_t insnCode,
+    const Config::insn_t insnCode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
-        target::insn_t i = insnCode;
+        Config::insn_t i = insnCode;
         const InsnFormat iformat =
             Entry::_insnFormat(pgm_read_byte(&entry->flags));
         switch (iformat) {
@@ -153,7 +153,7 @@ Error TableI8080::searchName(InsnI8080 &insn) const {
 }
 
 Error TableI8080::searchInsnCode(InsnI8080 &insn) const {
-    const target::insn_t insnCode = insn.insnCode();
+    const Config::insn_t insnCode = insn.insnCode();
     const Entry *entry = searchEntry(insnCode, ARRAY_RANGE(TABLE_I8080));
     if (!entry) return UNKNOWN_INSTRUCTION;
     insn.setFlags(pgm_read_byte(&entry->flags));

--- a/src/table_m6502.cpp
+++ b/src/table_m6502.cpp
@@ -421,7 +421,7 @@ Error TableM6502::searchInsnCode(
         if (!insn.supported(_cpuType)) continue;
         if (!acceptAddrMode(insn.addrMode(), acceptIndirectLong))
             continue;
-        char name[Entry::name_max + 1];
+        char name[Config::name_max + 1];
         pgm_strncpy(name, entry->name, sizeof(name));
         insn.setName(name);
         return OK;

--- a/src/table_m6502.cpp
+++ b/src/table_m6502.cpp
@@ -350,7 +350,7 @@ const Entry *TableM6502::searchEntry(
 }
 
 const Entry *TableM6502::searchEntry(
-    const target::insn_t insnCode, const Entry *table, const Entry *end) {
+    const Config::insn_t insnCode, const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
         if (insnCode == pgm_read_byte(&entry->insnCode))
             return entry;
@@ -413,7 +413,7 @@ static bool acceptAddrMode(AddrMode addrMode, bool acceptIndirectLong) {
 Error TableM6502::searchInsnCode(
     InsnM6502 &insn, bool acceptIndirectLong,
     const Entry *table, const Entry *end) const {
-    const target::insn_t insnCode = insn.insnCode();
+    const Config::insn_t insnCode = insn.insnCode();
     for (const Entry *entry = table;
          entry < end && (entry = searchEntry(insnCode, entry, end)) != nullptr;
          entry++) {

--- a/src/table_m6502.h
+++ b/src/table_m6502.h
@@ -39,7 +39,7 @@ private:
     static const Entry *searchEntry(
         const char *name, const Entry *table, const Entry *end);
     static const Entry *searchEntry(
-        const target::insn_t insnCode, const Entry *table, const Entry *end);
+        const Config::insn_t insnCode, const Entry *table, const Entry *end);
 
     Error searchName(
         InsnM6502 &insn,  const Entry *table, const Entry *end) const;

--- a/src/table_mc6800.cpp
+++ b/src/table_mc6800.cpp
@@ -239,7 +239,7 @@ Error TableMc6800::searchInsnCode(InsnMc6800 &insn) const {
     const Entry *entry = searchEntry(insn.insnCode(), ARRAY_RANGE(MC6800_TABLE));
     if (!entry) return UNKNOWN_INSTRUCTION;
     insn.setFlags(pgm_read_byte(&entry->flags));
-    char name[Entry::name_max + 1];
+    char name[Config::name_max + 1];
     pgm_strncpy(name, entry->name, sizeof(name));
     insn.setName(name);
     return OK;

--- a/src/table_mc6800.cpp
+++ b/src/table_mc6800.cpp
@@ -188,10 +188,10 @@ const Entry *TableMc6800::searchEntry(
 }
 
 const Entry *TableMc6800::searchEntry(
-    const target::insn_t insnCode,
+    const Config::insn_t insnCode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
-        target::insn_t opc = insnCode;
+        Config::insn_t opc = insnCode;
         const InsnAdjust iAdjust = Entry::_insnAdjust(pgm_read_byte(&entry->flags));
         switch (iAdjust) {
         case ADJ_AB01: opc &= ~1; break;

--- a/src/table_mc6800.h
+++ b/src/table_mc6800.h
@@ -36,7 +36,7 @@ private:
     static const Entry *searchEntry(
         const char *name, const Entry *table, const Entry *end);
     static const Entry *searchEntry(
-        const target::opcode_t opCode, const Entry *table, const Entry *end);
+        const Config::opcode_t opCode, const Entry *table, const Entry *end);
 };
 
 extern TableMc6800 TableMc6800;

--- a/src/table_mc68000.cpp
+++ b/src/table_mc68000.cpp
@@ -245,7 +245,7 @@ Error TableMc68000::searchInsnCode(InsnMc68000 &insn) const {
     const Entry *entry = searchEntry(insnCode, ARRAY_RANGE(TABLE_MC68000));
     if (!entry) return UNKNOWN_INSTRUCTION;
     insn.setFlags(pgm_read_byte(&entry->flags));
-    char name[Entry::name_max + 1];
+    char name[Config::name_max + 1];
     pgm_strncpy(name, entry->name, sizeof(name));
     insn.setName(name);
     return OK;

--- a/src/table_mc68000.cpp
+++ b/src/table_mc68000.cpp
@@ -177,7 +177,7 @@ static constexpr Entry TABLE_MC68000[] PROGMEM = {
     E(0160430, ROL,   DREG_ROT) // ROL.BWL #/Dx,Dn
 };
 
-static target::insn_t getInsnMask(InsnFormat iformat) {
+static Config::insn_t getInsnMask(InsnFormat iformat) {
     switch (iformat) {
     case MOVA_OPR: return 007077;
     case MOVE_OPR:
@@ -220,11 +220,11 @@ static const Entry *searchEntry(
 }
 
 static const Entry *searchEntry(
-    const target::insn_t insnCode,
+    const Config::insn_t insnCode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
         const host::uint_t flags = pgm_read_byte(&entry->flags);
-        const target::insn_t mask = getInsnMask(Entry::_insnFormat(flags));
+        const Config::insn_t mask = getInsnMask(Entry::_insnFormat(flags));
         if ((insnCode & ~mask) == pgm_read_word(&entry->insnCode))
             return entry;
     }
@@ -241,7 +241,7 @@ Error TableMc68000::searchName(InsnMc68000 &insn) const {
 }
 
 Error TableMc68000::searchInsnCode(InsnMc68000 &insn) const {
-    const target::insn_t insnCode = insn.insnCode();
+    const Config::insn_t insnCode = insn.insnCode();
     const Entry *entry = searchEntry(insnCode, ARRAY_RANGE(TABLE_MC68000));
     if (!entry) return UNKNOWN_INSTRUCTION;
     insn.setFlags(pgm_read_byte(&entry->flags));

--- a/src/table_mc6809.cpp
+++ b/src/table_mc6809.cpp
@@ -567,7 +567,7 @@ Error TableMc6809::searchInsnCode(
         const Entry *entry = searchEntry(insn.opCode(), page->table, page->end);
         if (entry) {
             insn.setFlags(pgm_read_byte(&entry->flags));
-            char name[Entry::name_max + 1];
+            char name[Config::name_max + 1];
             pgm_strncpy(name, entry->name, sizeof(name));
             insn.setName(name);
             return OK;

--- a/src/table_mc6809.cpp
+++ b/src/table_mc6809.cpp
@@ -500,11 +500,11 @@ static constexpr Entry HD6309_P11[] PROGMEM = {
     P11(0xFB, ADDF,  BYTE, HD6309, EXTD)
 };
 
-static constexpr target::opcode_t PREFIX_P00 = 0x00;
-static constexpr target::opcode_t PREFIX_P10 = 0x10;
-static constexpr target::opcode_t PREFIX_P11 = 0x11;
+static constexpr Config::opcode_t PREFIX_P00 = 0x00;
+static constexpr Config::opcode_t PREFIX_P10 = 0x10;
+static constexpr Config::opcode_t PREFIX_P11 = 0x11;
 
-bool TableMc6809::isPrefixCode(target::opcode_t opCode) {
+bool TableMc6809::isPrefixCode(Config::opcode_t opCode) {
     return opCode == PREFIX_P10 || opCode == PREFIX_P11;
 }
 
@@ -519,7 +519,7 @@ const Entry *TableMc6809::searchEntry(
 }
 
 const Entry *TableMc6809::searchEntry(
-    const target::opcode_t opCode,
+    const Config::opcode_t opCode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
         if (opCode == pgm_read_byte(&entry->opc))

--- a/src/table_mc6809.h
+++ b/src/table_mc6809.h
@@ -27,7 +27,7 @@ namespace mc6809 {
 #define PSEUDO_ASSUME  0x03     // reuse COM opecode
 
 struct EntryPage {
-    const target::opcode_t prefix;
+    const Config::opcode_t prefix;
     const Entry *const table;
     const Entry *const end;
 };
@@ -42,7 +42,7 @@ public:
     static const char *listCpu();
     bool is6309() const { return _cpuType == HD6309; }
 
-    static bool isPrefixCode(target::opcode_t opCode);
+    static bool isPrefixCode(Config::opcode_t opCode);
 
 private:
     CpuType _cpuType;
@@ -50,7 +50,7 @@ private:
     static const Entry *searchEntry(
         const char *name, const Entry *table, const Entry *end);
     static const Entry *searchEntry(
-        const target::opcode_t opCode, const Entry *table, const Entry *end);
+        const Config::opcode_t opCode, const Entry *table, const Entry *end);
 
     static Error searchName(
         InsnMc6809 &insn, const EntryPage *pages, const EntryPage *end);

--- a/src/table_tms9900.cpp
+++ b/src/table_tms9900.cpp
@@ -116,10 +116,10 @@ static const Entry *searchEntry(
 }
 
 static const Entry *searchEntry(
-    const target::insn_t insnCode,
+    const Config::insn_t insnCode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
-        target::insn_t i = insnCode;
+        Config::insn_t i = insnCode;
         const AddrMode addrMode = Entry::_addrMode(pgm_read_byte(&entry->flags));
         switch (addrMode) {
         case REG:
@@ -153,7 +153,7 @@ Error TableTms9900::searchName(InsnTms9900 &insn) const {
 }
 
 Error TableTms9900::searchInsnCode(InsnTms9900 &insn) const {
-    const target::insn_t insnCode = insn.insnCode();
+    const Config::insn_t insnCode = insn.insnCode();
     const Entry *entry = searchEntry(insnCode, ARRAY_RANGE(TABLE_TMS9900));
     if (!entry)
         return UNKNOWN_INSTRUCTION;

--- a/src/table_tms9900.cpp
+++ b/src/table_tms9900.cpp
@@ -160,7 +160,7 @@ Error TableTms9900::searchInsnCode(InsnTms9900 &insn) const {
     insn.setFlags(pgm_read_byte(&entry->flags));
     if (insn.is9995() && !is9995())
         return UNKNOWN_INSTRUCTION;
-    char name[Entry::name_max + 1];
+    char name[Config::name_max + 1];
     pgm_strncpy(name, entry->name, sizeof(name));
     insn.setName(name);
     return OK;

--- a/src/table_z80.cpp
+++ b/src/table_z80.cpp
@@ -333,7 +333,7 @@ static Error searchInsnCode(
         const Entry *entry = searchEntry(insn.opCode(), page->table, page->end);
         if (entry) {
             insn.setFlags(pgm_read_byte(&entry->flags1), pgm_read_byte(&entry->flags2));
-            char name[Entry::name_max + 1];
+            char name[Config::name_max + 1];
             pgm_strncpy(name, entry->name, sizeof(name));
             insn.setName(name);
             return OK;

--- a/src/table_z80.cpp
+++ b/src/table_z80.cpp
@@ -107,7 +107,7 @@ static constexpr Entry TABLE_00[] PROGMEM = {
     E(0xFE, CP,   NO_FMT,  A_REG,  IMM_8,  IMM8)
     E(0xC7, RST,  DST_FMT, VEC_NO, NO_OPR, INHR)
 };
-static constexpr target::opcode_t PREFIX_00 = 0x00;
+static constexpr Config::opcode_t PREFIX_00 = 0x00;
 
 static constexpr Entry TABLE_CB[] PROGMEM = {
     E(0x00, RLC,  SRC_FMT, REG_8,  NO_OPR, INHR)
@@ -131,7 +131,7 @@ static constexpr Entry TABLE_CB[] PROGMEM = {
     E(0x86, RES,  DST_FMT, BIT_NO, IX_OFF, INDX_IMM8)
     E(0xC6, SET,  DST_FMT, BIT_NO, IX_OFF, INDX_IMM8)
 };
-static constexpr target::opcode_t PREFIX_CB = 0xCB;
+static constexpr Config::opcode_t PREFIX_CB = 0xCB;
 
 static constexpr Entry TABLE_ED[] PROGMEM = {
     E(0x40, IN,   DST_FMT, REG_8,  C_PTR,  INHR)
@@ -165,7 +165,7 @@ static constexpr Entry TABLE_ED[] PROGMEM = {
     E(0xB3, OTIR, NO_FMT,  NO_OPR, NO_OPR, INHR)
     E(0xBB, OTDR, NO_FMT,  NO_OPR, NO_OPR, INHR)
 };
-static constexpr target::opcode_t PREFIX_ED = 0xED;
+static constexpr Config::opcode_t PREFIX_ED = 0xED;
 
 static constexpr Entry TABLE_IX[] PROGMEM = {
     E(0x09, ADD,  PTR_FMT, IX_REG, REG_16X,INHR)
@@ -200,7 +200,7 @@ static constexpr Entry TABLE_IX[] PROGMEM = {
     E(0xE5, PUSH, NO_FMT,  IX_REG, NO_OPR, INHR)
 };
 
-static constexpr target::opcode_t Z80_CODE[] PROGMEM = {
+static constexpr Config::opcode_t Z80_CODE[] PROGMEM = {
     0x08, // EX AF,AF'
     0x10, // DJNZ
     0x18, // JR
@@ -216,9 +216,9 @@ static constexpr target::opcode_t Z80_CODE[] PROGMEM = {
 };
 
 static bool checkZ80Code(
-    target::opcode_t opCode,
-    const target::opcode_t *table, const target::opcode_t *end) {
-    for (const target::opcode_t *entry = table; entry < end; entry++) {
+    Config::opcode_t opCode,
+    const Config::opcode_t *table, const Config::opcode_t *end) {
+    for (const Config::opcode_t *entry = table; entry < end; entry++) {
         if (opCode == pgm_read_byte(entry))
             return true;
     }
@@ -270,10 +270,10 @@ static const Entry *searchEntry(
 }
 
 static const Entry *searchEntry(
-    const target::opcode_t opcode,
+    const Config::opcode_t opcode,
     const Entry *table, const Entry *end) {
     for (const Entry *entry = table; entry < end; entry++) {
-        target::opcode_t opc = opcode;
+        Config::opcode_t opc = opcode;
         const InsnFormat iformat = Entry::_insnFormat(pgm_read_byte(&entry->flags1));
         switch (iformat) {
         case PTR_FMT: opc &= ~0x30; break;
@@ -292,7 +292,7 @@ static const Entry *searchEntry(
 }
 
 struct EntryPage {
-    const target::opcode_t prefix;
+    const Config::opcode_t prefix;
     const Entry *const table;
     const Entry *const end;
 };
@@ -353,7 +353,7 @@ static const EntryPage PAGES_Z80[] = {
     { TableZ80::PREFIX_IY, ARRAY_RANGE(TABLE_IX) },
 };
 
-bool TableZ80::isPrefixCode(target::opcode_t opCode) {
+bool TableZ80::isPrefixCode(Config::opcode_t opCode) {
     return opCode == PREFIX_CB || opCode == PREFIX_ED
         || opCode == TableZ80::PREFIX_IX || opCode == TableZ80::PREFIX_IY;
 }

--- a/src/table_z80.h
+++ b/src/table_z80.h
@@ -34,10 +34,10 @@ public:
     static const char *listCpu();
     bool isZ80() const { return _cpuType == Z80; }
 
-    static bool isPrefixCode(target::opcode_t opCode);
+    static bool isPrefixCode(Config::opcode_t opCode);
 
-    static constexpr target::opcode_t PREFIX_IX = 0xDD;
-    static constexpr target::opcode_t PREFIX_IY = 0xFD;
+    static constexpr Config::opcode_t PREFIX_IX = 0xDD;
+    static constexpr Config::opcode_t PREFIX_IY = 0xFD;
 
 private:
     CpuType _cpuType;

--- a/test/gen_driver.h
+++ b/test/gen_driver.h
@@ -30,7 +30,7 @@ namespace test {
 using libasm::cli::AsmLine;
 using libasm::cli::AsmListing;
 
-template<typename Addr>
+template<typename Addr, typename InsnUnit>
 class GenDriver : public TestGenerator<Addr>::Printer,
                   private AsmLine<Addr> {
 public:
@@ -82,14 +82,14 @@ private:
     bool _uppercase;
     FILE *_output;
     FILE *_list;
-    const Insn *_insn;
+    const Insn<Addr> *_insn;
     const char *_operands;
 
     // TestGenerator<Addr>::Printer
-    void print(const Insn &insn, const char *operands) override {
+    void print(const Insn<Addr> &insn, const char *operands) override {
         _insn = &insn;
         _operands = operands;
-        _listing.reset(*this, sizeof(target::opcode_t), _uppercase, false);
+        _listing.reset(*this, sizeof(InsnUnit), _uppercase, false);
         if (_list) {
             do {
                 fprintf(_list, "%s\n", _listing.getLine());

--- a/test/gen_i8080.cpp
+++ b/test/gen_i8080.cpp
@@ -22,13 +22,13 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisI8080 dis8080;
-    GenDriver<target::uintptr_t> driver(dis8080);
+    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis8080);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<target::uintptr_t> generator(
+    TestGenerator<Config::uintptr_t> generator(
         dis8080,
-        sizeof(target::opcode_t),
+        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_i8080.cpp
+++ b/test/gen_i8080.cpp
@@ -22,13 +22,12 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisI8080 dis8080;
-    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis8080);
+    GenDriver<Config> driver(dis8080);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<Config::uintptr_t> generator(
+    TestGenerator<Config> generator(
         dis8080,
-        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_m6502.cpp
+++ b/test/gen_m6502.cpp
@@ -22,13 +22,12 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisM6502 dis6502;
-    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6502);
+    GenDriver<Config> driver(dis6502);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<Config::uintptr_t> generator(
+    TestGenerator<Config> generator(
         dis6502,
-        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_m6502.cpp
+++ b/test/gen_m6502.cpp
@@ -22,13 +22,13 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisM6502 dis6502;
-    GenDriver<target::uintptr_t> driver(dis6502);
+    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6502);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<target::uintptr_t> generator(
+    TestGenerator<Config::uintptr_t> generator(
         dis6502,
-        sizeof(target::opcode_t),
+        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_mc6800.cpp
+++ b/test/gen_mc6800.cpp
@@ -22,13 +22,12 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisMc6800 dis6800;
-    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6800);
+    GenDriver<Config> driver(dis6800);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<Config::uintptr_t> generator(
+    TestGenerator<Config> generator(
         dis6800,
-        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_mc6800.cpp
+++ b/test/gen_mc6800.cpp
@@ -22,13 +22,13 @@ using namespace libasm::test;
 
 int main(int argc, const char **argv) {
     DisMc6800 dis6800;
-    GenDriver<target::uintptr_t> driver(dis6800);
+    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6800);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<target::uintptr_t> generator(
+    TestGenerator<Config::uintptr_t> generator(
         dis6800,
-        sizeof(target::opcode_t),
+        sizeof(Config::opcode_t),
         driver.uppercase());
     generator.generate(driver);
 

--- a/test/gen_mc6809.cpp
+++ b/test/gen_mc6809.cpp
@@ -32,13 +32,13 @@ static bool filterHd6309BitImmIndexed(uint8_t opc) {
 
 int main(int argc, const char **argv) {
     DisMc6809 dis6809;
-    GenDriver<target::uintptr_t> driver(dis6809);
+    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6809);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<target::uintptr_t> generator(
+    TestGenerator<Config::uintptr_t> generator(
         dis6809,
-        sizeof(target::opcode_t),
+        sizeof(Config::opcode_t),
         driver.uppercase());
     generator
         .generate(driver, filterHd6309BitImmIndexed)

--- a/test/gen_mc6809.cpp
+++ b/test/gen_mc6809.cpp
@@ -32,13 +32,12 @@ static bool filterHd6309BitImmIndexed(uint8_t opc) {
 
 int main(int argc, const char **argv) {
     DisMc6809 dis6809;
-    GenDriver<Config::uintptr_t, Config::opcode_t> driver(dis6809);
+    GenDriver<Config> driver(dis6809);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<Config::uintptr_t> generator(
+    TestGenerator<Config> generator(
         dis6809,
-        sizeof(Config::opcode_t),
         driver.uppercase());
     generator
         .generate(driver, filterHd6309BitImmIndexed)

--- a/test/gen_z80.cpp
+++ b/test/gen_z80.cpp
@@ -35,13 +35,13 @@ static bool filterZ80IxBitPrefix(uint8_t opc) {
 
 int main(int argc, const char **argv) {
     DisZ80 disz80;
-    GenDriver<target::uintptr_t> driver(disz80);
+    GenDriver<Config::uintptr_t, Config::opcode_t> driver(disz80);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<target::uintptr_t> generator(
+    TestGenerator<Config::uintptr_t> generator(
         disz80,
-        sizeof(target::opcode_t),
+        sizeof(Config::opcode_t),
         driver.uppercase());
     generator
         .generate(driver, filterZ80Prefix)

--- a/test/gen_z80.cpp
+++ b/test/gen_z80.cpp
@@ -35,13 +35,12 @@ static bool filterZ80IxBitPrefix(uint8_t opc) {
 
 int main(int argc, const char **argv) {
     DisZ80 disz80;
-    GenDriver<Config::uintptr_t, Config::opcode_t> driver(disz80);
+    GenDriver<Config> driver(disz80);
     if (driver.main(argc, argv))
         return 1;
 
-    TestGenerator<Config::uintptr_t> generator(
+    TestGenerator<Config> generator(
         disz80,
-        sizeof(Config::opcode_t),
         driver.uppercase());
     generator
         .generate(driver, filterZ80Prefix)

--- a/test/test_asm_helper.h
+++ b/test/test_asm_helper.h
@@ -22,12 +22,9 @@
 
 #include <stdio.h>
 
-extern libasm::test::TestAsserter asserter;
-extern libasm::test::TestSymtab symtab;
-
 #define EASSERT(error, addr, line, expected)                    \
     do {                                                        \
-        Insn insn;                                              \
+        Insn<Config::uintptr_t> insn;                           \
         char message[80];                                       \
         symtab.setCurrentOrigin(addr);                          \
         assembler.encode(line, insn, addr, &symtab);            \
@@ -38,7 +35,7 @@ extern libasm::test::TestSymtab symtab;
     } while (0)
 #define EATEST(error, addr, line, ...)                          \
     do {                                                        \
-        const target::opcode_t expected[] = { __VA_ARGS__ };    \
+        const Config::opcode_t expected[] = { __VA_ARGS__ };    \
         EASSERT(error, addr, line, expected);                   \
     } while (0)
 #define ATEST(addr, line, ...) EATEST(OK, addr, line, __VA_ARGS__)

--- a/test/test_asm_helper.h
+++ b/test/test_asm_helper.h
@@ -24,7 +24,7 @@
 
 #define EASSERT(error, addr, line, expected)                    \
     do {                                                        \
-        Insn<Config::uintptr_t> insn;                           \
+        Insn<Config> insn;                                      \
         char message[80];                                       \
         symtab.setCurrentOrigin(addr);                          \
         assembler.encode(line, insn, addr, &symtab);            \

--- a/test/test_asm_i8080.cpp
+++ b/test/test_asm_i8080.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmI8080 as8080;
-Assembler<target::uintptr_t> &assembler(as8080);
+Assembler<Config::uintptr_t> &assembler(as8080);
 
 static void set_up() {
 }

--- a/test/test_asm_i8080.cpp
+++ b/test/test_asm_i8080.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmI8080 as8080;
-Assembler<Config::uintptr_t> &assembler(as8080);
+Assembler<Config> &assembler(as8080);
 
 static void set_up() {
 }

--- a/test/test_asm_m6502.cpp
+++ b/test/test_asm_m6502.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmM6502 as6502;
-Assembler<Config::uintptr_t> &assembler(as6502);
+Assembler<Config> &assembler(as6502);
 
 static void set_up() {
     assembler.setCpu("6502");

--- a/test/test_asm_m6502.cpp
+++ b/test/test_asm_m6502.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmM6502 as6502;
-Assembler<target::uintptr_t> &assembler(as6502);
+Assembler<Config::uintptr_t> &assembler(as6502);
 
 static void set_up() {
     assembler.setCpu("6502");

--- a/test/test_asm_mc6800.cpp
+++ b/test/test_asm_mc6800.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc6800 as6800;
-Assembler<target::uintptr_t> &assembler(as6800);
+Assembler<Config::uintptr_t> &assembler(as6800);
 
 static void set_up() {
 }

--- a/test/test_asm_mc6800.cpp
+++ b/test/test_asm_mc6800.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc6800 as6800;
-Assembler<Config::uintptr_t> &assembler(as6800);
+Assembler<Config> &assembler(as6800);
 
 static void set_up() {
 }

--- a/test/test_asm_mc68000.cpp
+++ b/test/test_asm_mc68000.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc68000 as68000;
-Assembler<target::uintptr_t> &assembler(as68000);
+Assembler<Config::uintptr_t> &assembler(as68000);
 
 static void set_up() {
 }

--- a/test/test_asm_mc68000.cpp
+++ b/test/test_asm_mc68000.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc68000 as68000;
-Assembler<Config::uintptr_t> &assembler(as68000);
+Assembler<Config> &assembler(as68000);
 
 static void set_up() {
 }

--- a/test/test_asm_mc6809.cpp
+++ b/test/test_asm_mc6809.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc6809 as6809;
-Assembler<Config::uintptr_t> &assembler(as6809);
+Assembler<Config> &assembler(as6809);
 
 static void set_up() {
     TEST("SETDP 0");

--- a/test/test_asm_mc6809.cpp
+++ b/test/test_asm_mc6809.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmMc6809 as6809;
-Assembler<target::uintptr_t> &assembler(as6809);
+Assembler<Config::uintptr_t> &assembler(as6809);
 
 static void set_up() {
     TEST("SETDP 0");

--- a/test/test_asm_tms9900.cpp
+++ b/test/test_asm_tms9900.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmTms9900 as9900;
-Assembler<Config::uintptr_t> &assembler(as9900);
+Assembler<Config> &assembler(as9900);
 
 static void set_up() {
     assembler.setCpu("tms9900");

--- a/test/test_asm_tms9900.cpp
+++ b/test/test_asm_tms9900.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmTms9900 as9900;
-Assembler<target::uintptr_t> &assembler(as9900);
+Assembler<Config::uintptr_t> &assembler(as9900);
 
 static void set_up() {
     assembler.setCpu("tms9900");

--- a/test/test_asm_z80.cpp
+++ b/test/test_asm_z80.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmZ80 asz80;
-Assembler<Config::uintptr_t> &assembler(asz80);
+Assembler<Config> &assembler(asz80);
 
 static void set_up() {
     assembler.setCpu("8080");

--- a/test/test_asm_z80.cpp
+++ b/test/test_asm_z80.cpp
@@ -24,7 +24,7 @@ using namespace libasm::test;
 TestAsserter asserter;
 TestSymtab symtab;
 AsmZ80 asz80;
-Assembler<target::uintptr_t> &assembler(asz80);
+Assembler<Config::uintptr_t> &assembler(asz80);
 
 static void set_up() {
     assembler.setCpu("8080");

--- a/test/test_dis_helper.h
+++ b/test/test_dis_helper.h
@@ -26,7 +26,7 @@
 
 #define EASSERT(error, addr, mnemonic, expected_operands)           \
     do {                                                            \
-        Insn<Config::uintptr_t> insn;                               \
+        Insn<Config> insn;                                          \
         char operands[40], message[80];                             \
         memory.setAddress(addr);                                    \
         disassembler.decode(memory, insn, operands, &symtab, true); \

--- a/test/test_dis_helper.h
+++ b/test/test_dis_helper.h
@@ -24,13 +24,9 @@
 
 #include <stdio.h>
 
-extern libasm::test::TestAsserter asserter;
-extern libasm::test::TestMemory memory;
-extern libasm::test::TestSymtab symtab;
-
 #define EASSERT(error, addr, mnemonic, expected_operands)           \
     do {                                                            \
-        Insn insn;                                                  \
+        Insn<Config::uintptr_t> insn;                               \
         char operands[40], message[80];                             \
         memory.setAddress(addr);                                    \
         disassembler.decode(memory, insn, operands, &symtab, true); \
@@ -47,7 +43,7 @@ extern libasm::test::TestSymtab symtab;
     } while (0)
 #define EATEST(error, addr, mnemonic, opr, ...)                 \
     do {                                                        \
-        const target::opcode_t mnemonic[] = { __VA_ARGS__ };    \
+        const Config::opcode_t mnemonic[] = { __VA_ARGS__ };    \
         memory.setMemory(mnemonic, sizeof(mnemonic));           \
         EASSERT(error, addr, mnemonic, opr);                    \
     } while (0)

--- a/test/test_dis_i8080.cpp
+++ b/test/test_dis_i8080.cpp
@@ -22,10 +22,10 @@ using namespace libasm::i8080;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisI8080 dis8080;
-Disassembler<Config::uintptr_t> &disassembler(dis8080);
+Disassembler<Config> &disassembler(dis8080);
 
 static void set_up() {
 }

--- a/test/test_dis_i8080.cpp
+++ b/test/test_dis_i8080.cpp
@@ -22,10 +22,10 @@ using namespace libasm::i8080;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisI8080 dis8080;
-Disassembler<target::uintptr_t> &disassembler(dis8080);
+Disassembler<Config::uintptr_t> &disassembler(dis8080);
 
 static void set_up() {
 }

--- a/test/test_dis_m6502.cpp
+++ b/test/test_dis_m6502.cpp
@@ -22,10 +22,10 @@ using namespace libasm::m6502;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisM6502 dis6502;
-Disassembler<target::uintptr_t> &disassembler(dis6502);
+Disassembler<Config::uintptr_t> &disassembler(dis6502);
 
 static void set_up() {
     disassembler.setCpu("6502");
@@ -661,7 +661,7 @@ static void test_no_idir_long() {
 static void test_illegal_m6502() {
     disassembler.setCpu("6502");
 
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     char operands[40];
 
     const uint8_t illegals[] = {
@@ -689,7 +689,7 @@ static void test_illegal_m6502() {
 static void test_illegal_w65sc02() {
     disassembler.setCpu("65SC02");
 
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     char operands[40];
 
     const uint8_t illegals[] = {

--- a/test/test_dis_m6502.cpp
+++ b/test/test_dis_m6502.cpp
@@ -22,10 +22,10 @@ using namespace libasm::m6502;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisM6502 dis6502;
-Disassembler<Config::uintptr_t> &disassembler(dis6502);
+Disassembler<Config> &disassembler(dis6502);
 
 static void set_up() {
     disassembler.setCpu("6502");
@@ -661,7 +661,7 @@ static void test_no_idir_long() {
 static void test_illegal_m6502() {
     disassembler.setCpu("6502");
 
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     char operands[40];
 
     const uint8_t illegals[] = {
@@ -689,7 +689,7 @@ static void test_illegal_m6502() {
 static void test_illegal_w65sc02() {
     disassembler.setCpu("65SC02");
 
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     char operands[40];
 
     const uint8_t illegals[] = {

--- a/test/test_dis_mc6800.cpp
+++ b/test/test_dis_mc6800.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc6800;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisMc6800 dis6800;
-Disassembler<target::uintptr_t> &disassembler(dis6800);
+Disassembler<Config::uintptr_t> &disassembler(dis6800);
 
 static void set_up() {
 }
@@ -324,7 +324,7 @@ static void test_relative() {
 
 static void assert_illegal(uint8_t opc) {
     char operands[40];
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     const uint8_t codes[] = { opc };
     memory.setMemory(&codes[0], 1);
     disassembler.decode(memory, insn, operands, nullptr);

--- a/test/test_dis_mc6800.cpp
+++ b/test/test_dis_mc6800.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc6800;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisMc6800 dis6800;
-Disassembler<Config::uintptr_t> &disassembler(dis6800);
+Disassembler<Config> &disassembler(dis6800);
 
 static void set_up() {
 }
@@ -324,7 +324,7 @@ static void test_relative() {
 
 static void assert_illegal(uint8_t opc) {
     char operands[40];
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     const uint8_t codes[] = { opc };
     memory.setMemory(&codes[0], 1);
     disassembler.decode(memory, insn, operands, nullptr);

--- a/test/test_dis_mc68000.cpp
+++ b/test/test_dis_mc68000.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc68000;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisMc68000 dis68000;
-Disassembler<target::uintptr_t> &disassembler(dis68000);
+Disassembler<Config::uintptr_t> &disassembler(dis68000);
 
 static void set_up() {
 }

--- a/test/test_dis_mc68000.cpp
+++ b/test/test_dis_mc68000.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc68000;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisMc68000 dis68000;
-Disassembler<Config::uintptr_t> &disassembler(dis68000);
+Disassembler<Config> &disassembler(dis68000);
 
 static void set_up() {
 }

--- a/test/test_dis_mc6809.cpp
+++ b/test/test_dis_mc6809.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc6809;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisMc6809 dis6809;
-Disassembler<target::uintptr_t> &disassembler(dis6809);
+Disassembler<Config::uintptr_t> &disassembler(dis6809);
 
 static void set_up() {
     disassembler.setCpu("6809");
@@ -1030,7 +1030,7 @@ static void test_bit_position() {
 
 static void assert_illegal(uint8_t opc, uint8_t prefix = 0) {
     char operands[40];
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     const uint8_t codes[] = { prefix, opc };
     if (prefix == 0) {
         memory.setMemory(&codes[1], 1);

--- a/test/test_dis_mc6809.cpp
+++ b/test/test_dis_mc6809.cpp
@@ -22,10 +22,10 @@ using namespace libasm::mc6809;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisMc6809 dis6809;
-Disassembler<Config::uintptr_t> &disassembler(dis6809);
+Disassembler<Config> &disassembler(dis6809);
 
 static void set_up() {
     disassembler.setCpu("6809");
@@ -1030,7 +1030,7 @@ static void test_bit_position() {
 
 static void assert_illegal(uint8_t opc, uint8_t prefix = 0) {
     char operands[40];
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     const uint8_t codes[] = { prefix, opc };
     if (prefix == 0) {
         memory.setMemory(&codes[1], 1);

--- a/test/test_dis_tms9900.cpp
+++ b/test/test_dis_tms9900.cpp
@@ -22,10 +22,10 @@ using namespace libasm::tms9900;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisTms9900 dis9900;
-Disassembler<target::uintptr_t> &disassembler(dis9900);
+Disassembler<Config::uintptr_t> &disassembler(dis9900);
 
 static void set_up() {
     disassembler.setCpu("tms9900");
@@ -256,7 +256,7 @@ static void test_mid_tms9900() {
         { 0x0780, 0x07ff }, { 0x0c00, 0x0fff }
     };
     uint8_t bytes[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     char operands[40], message[40];
     const mid_range *m = &mids[0];
 
@@ -302,7 +302,7 @@ static void test_mid_tms9995() {
         { 0x0780, 0x07ff }, { 0x0c00, 0x0fff }
     };
     uint8_t bytes[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     char operands[40], message[40];
     const mid_range *m = &mids[0];
 

--- a/test/test_dis_tms9900.cpp
+++ b/test/test_dis_tms9900.cpp
@@ -22,10 +22,10 @@ using namespace libasm::tms9900;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisTms9900 dis9900;
-Disassembler<Config::uintptr_t> &disassembler(dis9900);
+Disassembler<Config> &disassembler(dis9900);
 
 static void set_up() {
     disassembler.setCpu("tms9900");
@@ -256,7 +256,7 @@ static void test_mid_tms9900() {
         { 0x0780, 0x07ff }, { 0x0c00, 0x0fff }
     };
     uint8_t bytes[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     char operands[40], message[40];
     const mid_range *m = &mids[0];
 
@@ -302,7 +302,7 @@ static void test_mid_tms9995() {
         { 0x0780, 0x07ff }, { 0x0c00, 0x0fff }
     };
     uint8_t bytes[6] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     char operands[40], message[40];
     const mid_range *m = &mids[0];
 

--- a/test/test_dis_z80.cpp
+++ b/test/test_dis_z80.cpp
@@ -22,10 +22,10 @@ using namespace libasm::z80;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory memory;
+TestMemory<Config::uintptr_t> memory;
 TestSymtab symtab;
 DisZ80 disz80;
-Disassembler<target::uintptr_t> &disassembler(disz80);
+Disassembler<Config::uintptr_t> &disassembler(disz80);
 
 static void set_up() {
     disassembler.setCpu("8080");
@@ -681,7 +681,7 @@ static void test_illegal_i8080() {
 
 static void assert_illegal(uint8_t prefix, uint8_t opc, uint8_t opr1 = 0, uint8_t opr2 = 0) {
     char operands[40];
-    Insn insn;
+    Insn<Config::uintptr_t> insn;
     const uint8_t codes[] = { prefix, opc, opr1, opr2 };
     memory.setMemory(&codes[0], sizeof(codes));
     disassembler.decode(memory, insn, operands, nullptr);

--- a/test/test_dis_z80.cpp
+++ b/test/test_dis_z80.cpp
@@ -22,10 +22,10 @@ using namespace libasm::z80;
 using namespace libasm::test;
 
 TestAsserter asserter;
-TestMemory<Config::uintptr_t> memory;
+TestMemory<Config> memory;
 TestSymtab symtab;
 DisZ80 disz80;
-Disassembler<Config::uintptr_t> &disassembler(disz80);
+Disassembler<Config> &disassembler(disz80);
 
 static void set_up() {
     disassembler.setCpu("8080");
@@ -681,7 +681,7 @@ static void test_illegal_i8080() {
 
 static void assert_illegal(uint8_t prefix, uint8_t opc, uint8_t opr1 = 0, uint8_t opr2 = 0) {
     char operands[40];
-    Insn<Config::uintptr_t> insn;
+    Insn<Config> insn;
     const uint8_t codes[] = { prefix, opc, opr1, opr2 };
     memory.setMemory(&codes[0], sizeof(codes));
     disassembler.decode(memory, insn, operands, nullptr);

--- a/test/test_generator.h
+++ b/test/test_generator.h
@@ -133,20 +133,20 @@ private:
     }
 };
 
-template<typename Addr>
-class TestData : private DisMemory<Addr> {
+template<typename Conf>
+class TestData : private DisMemory<Conf> {
 public:
     TestData()
-        : DisMemory<Addr>(0),
+        : DisMemory<Conf>(0),
           _operands(60)
     {}
 
-    const Insn<Addr> &insn() const { return _insn; }
+    const Insn<Conf> &insn() const { return _insn; }
     TextBuffer &operands() { return _operands; }
     const TextBuffer &operands() const { return _operands; }
     Error tryGenerate(
-        Disassembler<Addr> &dis,
-        Addr addr,
+        Disassembler<Conf> &dis,
+        typename Conf::uintptr_t addr,
         uint8_t *memory,
         int size,
         bool uppercase) {
@@ -164,24 +164,23 @@ private:
     uint8_t *_memory;
     int _memorySize;
     int _memoryIndex;
-    Insn<Addr> _insn;
+    Insn<Conf> _insn;
 
-    // DisMemory<Addr>
+    // DisMemory<Conf>
     bool hasNext() const override { return _memoryIndex < _memorySize; }
     uint8_t nextByte() override { return _memory[_memoryIndex++]; }
 };
 
-template<typename Addr>
+template<typename Conf>
 class TestGenerator {
 public:
     TestGenerator(
-        Disassembler<Addr> &disassembler,
-        size_t opcodeSize,
+        Disassembler<Conf> &disassembler,
         bool uppercase)
         : _disassembler(disassembler),
-          _memorySize(disassembler.maxBytes()),
-          _endian(disassembler.endian()),
-          _opcodeSize(opcodeSize),
+          _memorySize(Conf::code_max),
+          _endian(Conf::endian),
+          _opcodeSize(sizeof(typename Conf::opcode_t)),
           _uppercase(uppercase) {
         _memory = new uint8_t[_memorySize];
         _addr = 0;
@@ -193,16 +192,16 @@ public:
 
     class Printer {
     public:
-        virtual void print(const Insn<Addr> &insn, const char *operands) = 0;
+        virtual void print(const Insn<Conf> &insn, const char *operands) = 0;
     };
     typedef bool (*Filter)(uint8_t);
 
-    TestGenerator<Addr> &generate(Printer &printer, Filter filter = nullptr) {
+    TestGenerator<Conf> &generate(Printer &printer, Filter filter = nullptr) {
         DataGenerator gen(_memory, _endian, _opcodeSize, filter);
         return generate(printer, gen);
     }
 
-    TestGenerator<Addr> &generate(
+    TestGenerator<Conf> &generate(
         Printer &printer, uint8_t opc1, Filter filter = nullptr) {
         DataGenerator parent(_memory, _endian, _opcodeSize);
         parent.outUint8(opc1);
@@ -210,7 +209,7 @@ public:
         return generate(printer, gen);
     }
 
-    TestGenerator<Addr> &generate(
+    TestGenerator<Conf> &generate(
         Printer &printer, uint8_t opc1, uint8_t opc2) {
         DataGenerator parent(_memory, _endian, _opcodeSize * 2);
         parent.outUint8(opc1, 0);
@@ -219,7 +218,7 @@ public:
         return generate(printer, gen);
     }
 
-    TestGenerator<Addr> &generate(
+    TestGenerator<Conf> &generate(
         Printer &printer, uint8_t opc1, uint8_t opc2, uint8_t opc3) {
         DataGenerator parent(_memory, _endian, _opcodeSize * 3);
         parent.outUint8(opc1, 0);
@@ -230,22 +229,22 @@ public:
     }
 
 private:
-    Disassembler<Addr> &_disassembler;
+    Disassembler<Conf> &_disassembler;
     const int _memorySize;
     const Endian _endian;
     const size_t _opcodeSize;
     const bool _uppercase;
     uint8_t *_memory;
-    TestData<Addr> _data1;
-    TestData<Addr> _data2;
+    TestData<Conf> _data1;
+    TestData<Conf> _data2;
 
-    Addr _addr;
+    typename Conf::uintptr_t _addr;
     Printer *_printer;
-    TestData<Addr> *_data;
-    TestData<Addr> *_prev;
+    TestData<Conf> *_data;
+    TestData<Conf> *_prev;
     int _similarCount;
 
-    TestGenerator<Addr> &generate(Printer &printer, DataGenerator &gen) {
+    TestGenerator<Conf> &generate(Printer &printer, DataGenerator &gen) {
         _printer = &printer;
         _data = &_data1;
         _prev = &_data2;
@@ -254,7 +253,7 @@ private:
         return *this;
     }
 
-    void printInsn(const TestData<Addr> *data) {
+    void printInsn(const TestData<Conf> *data) {
         _printer->print(data->insn(), data->operands().buffer());
         _addr += data->insn().length();
     }

--- a/test/test_generator.h
+++ b/test/test_generator.h
@@ -141,7 +141,7 @@ public:
           _operands(60)
     {}
 
-    const Insn &insn() const { return _insn; }
+    const Insn<Addr> &insn() const { return _insn; }
     TextBuffer &operands() { return _operands; }
     const TextBuffer &operands() const { return _operands; }
     Error tryGenerate(
@@ -164,7 +164,7 @@ private:
     uint8_t *_memory;
     int _memorySize;
     int _memoryIndex;
-    Insn _insn;
+    Insn<Addr> _insn;
 
     // DisMemory<Addr>
     bool hasNext() const override { return _memoryIndex < _memorySize; }
@@ -193,7 +193,7 @@ public:
 
     class Printer {
     public:
-        virtual void print(const Insn &insn, const char *operands) = 0;
+        virtual void print(const Insn<Addr> &insn, const char *operands) = 0;
     };
     typedef bool (*Filter)(uint8_t);
 
@@ -203,7 +203,7 @@ public:
     }
 
     TestGenerator<Addr> &generate(
-        Printer &printer, target::opcode_t opc1, Filter filter = nullptr) {
+        Printer &printer, uint8_t opc1, Filter filter = nullptr) {
         DataGenerator parent(_memory, _endian, _opcodeSize);
         parent.outUint8(opc1);
         DataGenerator gen(parent, _opcodeSize, filter);
@@ -211,7 +211,7 @@ public:
     }
 
     TestGenerator<Addr> &generate(
-        Printer &printer, target::opcode_t opc1, target::opcode_t opc2) {
+        Printer &printer, uint8_t opc1, uint8_t opc2) {
         DataGenerator parent(_memory, _endian, _opcodeSize * 2);
         parent.outUint8(opc1, 0);
         parent.outUint8(opc2, 1);
@@ -220,8 +220,7 @@ public:
     }
 
     TestGenerator<Addr> &generate(
-        Printer &printer,
-        target::opcode_t opc1, target::opcode_t opc2, target::opcode_t opc3) {
+        Printer &printer, uint8_t opc1, uint8_t opc2, uint8_t opc3) {
         DataGenerator parent(_memory, _endian, _opcodeSize * 3);
         parent.outUint8(opc1, 0);
         parent.outUint8(opc2, 1);

--- a/test/test_memory.h
+++ b/test/test_memory.h
@@ -26,11 +26,11 @@
 namespace libasm {
 namespace test {
 
-template<typename Addr>
-class TestMemory : public DisMemory<Addr> {
+template<typename Conf>
+class TestMemory : public DisMemory<Conf> {
 public:
     TestMemory()
-        : DisMemory<Addr>(0),
+        : DisMemory<Conf>(0),
           _bytes(nullptr),
           _words(nullptr)
     {}
@@ -48,7 +48,9 @@ public:
         _index = 0;
     }
     bool hasNext() const override { return _index < _size; }
-    void setAddress(Addr addr) { this->_address = addr; }
+    void setAddress(typename Conf::uintptr_t addr) {
+        this->_address = addr;
+    }
     char *dump(char *out) {
         if (_words) {
             for (host::uint_t idx = 0; idx < _size; idx += 2) {

--- a/test/test_memory.h
+++ b/test/test_memory.h
@@ -26,18 +26,29 @@
 namespace libasm {
 namespace test {
 
-class TestMemory : public DisMemory<target::uintptr_t> {
+template<typename Addr>
+class TestMemory : public DisMemory<Addr> {
 public:
     TestMemory()
-        : DisMemory(0),
+        : DisMemory<Addr>(0),
           _bytes(nullptr),
           _words(nullptr)
     {}
 
-    template<typename T>
-    void setMemory(const T *data, host::uint_t size);
+    void setMemory(const uint8_t *data, host::uint_t size) {
+        _bytes = data;
+        _words = nullptr;
+        _size = size;
+        _index = 0;
+    }
+    void setMemory(const uint16_t*data, host::uint_t size) {
+        _bytes = nullptr;
+        _words = data;
+        _size = size;
+        _index = 0;
+    }
     bool hasNext() const override { return _index < _size; }
-    void setAddress(target::uintptr_t addr) { _address = addr; }
+    void setAddress(Addr addr) { this->_address = addr; }
     char *dump(char *out) {
         if (_words) {
             for (host::uint_t idx = 0; idx < _size; idx += 2) {
@@ -69,22 +80,6 @@ private:
     host::uint_t _size;
     host::uint_t _index;
 };
-
-template<>
-void TestMemory::setMemory<uint8_t>(const uint8_t *data, host::uint_t size) {
-    _bytes = data;
-    _words = nullptr;
-    _size = size;
-    _index = 0;
-}
-
-template<>
-void TestMemory::setMemory<uint16_t>(const uint16_t *data, host::uint_t size) {
-    _bytes = nullptr;
-    _words = data;
-    _size = size;
-    _index = 0;
-}
 
 } // namespace test
 } // namespace libasm


### PR DESCRIPTION
No symbol is exported to global namespace.
Now assembler and disassembler of different CPUs can be linked simultaneously.