### PR TITLE
Refactor InsnBase and RegBase classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # libasm: cross assemble/disassemble library
 
 The libasm allows assembling and disassembling supported retro CPUs on
-a small environment (less than ~15kB Flash and ~700B RAM on AVR
+a small environment (less than 10kB~19kB Flash and ~350B RAM on AVR
 Arduino).
 
 * Supported target CPUs.

--- a/src/asm_base.cpp
+++ b/src/asm_base.cpp
@@ -24,12 +24,12 @@ namespace libasm {
 
 Error Assembler::encode(
     const char *line, Insn &insn, uint32_t addr, SymbolTable *symtab) {
-    this->resetError();
+    resetError();
+    _symtab = symtab;
     _scan = skipSpaces(line);
     if (checkLineEnd() == OK)
         return setError(NO_INSTRUCTION);
-    this->resetError();
-    _symtab = symtab;
+    resetError();
     insn.resetAddress(addr);
     return encode(insn);
 }
@@ -54,7 +54,7 @@ bool Assembler::endOfLine(const char *scan) const {
 
 Error Assembler::checkLineEnd(const char *scan) {
     if (scan == nullptr) scan = _scan;
-    if (this->endOfLine(skipSpaces(scan)))
+    if (endOfLine(skipSpaces(scan)))
         return getError();
     return setErrorIf(GARBAGE_AT_END);
 }

--- a/src/asm_cdp1802.cpp
+++ b/src/asm_cdp1802.cpp
@@ -78,6 +78,7 @@ Error AsmCdp1802::encode(Insn &_insn) {
     InsnCdp1802 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
+
     if (TableCdp1802.searchName(insn))
         return setError(TableCdp1802.getError());
     _scan = skipSpaces(endName);

--- a/src/asm_i8051.cpp
+++ b/src/asm_i8051.cpp
@@ -38,14 +38,14 @@ Error AsmI8051::parseOperand(Operand &op) {
         if (isspace(*p)) return setError(UNKNOWN_OPERAND);
     }
 
-    op.reg = _regs.parseRegister(p);
+    op.reg = RegI8051::parseRegName(p);
     if (op.reg != REG_UNDEF) {
-        p += _regs.regNameLen(op.reg);
+        p += RegI8051::regNameLen(op.reg);
         if (indir && op.reg == REG_A && *p == '+') {
             p++;
-            const RegName base = _regs.parseRegister(p);
+            const RegName base = RegI8051::parseRegName(p);
             if (base == REG_DPTR || base == REG_PC) {
-                _scan = p + _regs.regNameLen(base);
+                _scan = p + RegI8051::regNameLen(base);
                 op.mode = (base == REG_DPTR) ? INDXD : INDXP;
                 return OK;
             }
@@ -65,7 +65,7 @@ Error AsmI8051::parseOperand(Operand &op) {
         }
         if (op.reg == REG_A) {
             op.mode = AREG;
-        } else if (_regs.isRReg(op.reg)) {
+        } else if (RegI8051::isRReg(op.reg)) {
             op.mode = RREG;
         } else if (op.reg == REG_C) {
             op.mode = CREG;
@@ -126,7 +126,7 @@ Error AsmI8051::encodeOperand(
         }
     }
     if (mode == RREG || mode == IDIRR) {
-        insn.embed(_regs.encodeRReg(op.reg));
+        insn.embed(RegI8051::encodeRReg(op.reg));
         return OK;
     }
     if (mode == ADR8) {

--- a/src/asm_i8051.cpp
+++ b/src/asm_i8051.cpp
@@ -200,6 +200,7 @@ Error AsmI8051::encode(Insn &_insn) {
     insn.setAddrMode(dstOp.mode, srcOp.mode, extOp.mode);
     if (TableI8051.searchName(insn))
         return setError(UNKNOWN_INSTRUCTION);
+
     const AddrMode dst = insn.dstMode();
     const AddrMode src = insn.srcMode();
     const AddrMode ext = insn.extMode();

--- a/src/asm_i8051.h
+++ b/src/asm_i8051.h
@@ -35,7 +35,6 @@ public:
 
 private:
     IntelValueParser _parser;
-    RegI8051 _regs;
 
     TableBase &getTable() const override { return TableI8051; }
 

--- a/src/asm_i8080.cpp
+++ b/src/asm_i8080.cpp
@@ -88,9 +88,9 @@ Error AsmI8080::encodeVectorNo(InsnI8080 &insn) {
 
 Error AsmI8080::encodeImmediate(InsnI8080 &insn) {
     if (insn.insnFormat() != NO_FORMAT) {
-        _scan = skipSpaces(_scan);
-        if (*_scan != ',') return setError(MISSING_COMMA);
-        _scan++;
+        const char *p = skipSpaces(_scan);
+        if (*p != ',') return setError(MISSING_COMMA);
+        _scan = p + 1;
     }
     if (insn.addrMode() == IMM8) {
         uint8_t val8;
@@ -122,8 +122,9 @@ Error AsmI8080::encode(Insn &_insn) {
     InsnI8080 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
+
     if (TableI8080.searchName(insn))
-        return setError(UNKNOWN_INSTRUCTION);
+        return setError(TableI8080.getError());
     _scan = skipSpaces(endName);
 
     switch (insn.insnFormat()) {

--- a/src/asm_i8080.cpp
+++ b/src/asm_i8080.cpp
@@ -21,61 +21,57 @@ namespace libasm {
 namespace i8080 {
 
 Error AsmI8080::encodePointerReg(InsnI8080 &insn) {
-    const RegName regName = _regs.parsePointerReg(_scan);
-    const int8_t num = _regs.encodePointerReg(regName);
-    if (num < 0) return setError(UNKNOWN_REGISTER);
-    insn.embed(num << 4);
-    _scan += _regs.regNameLen(regName);
-    return setOK();
+    const RegName reg = RegI8080::parseRegName(_scan);
+    if (!RegI8080::isPointerReg(reg)) return setError(UNKNOWN_REGISTER);
+    insn.embed(RegI8080::encodePointerReg(reg));
+    _scan += RegI8080::regNameLen(reg);
+    return OK;
 }
 
 Error AsmI8080::encodeStackReg(InsnI8080 &insn) {
-    const RegName regName = _regs.parseStackReg(_scan);
-    const int8_t num = _regs.encodeStackReg(regName);
-    if (num < 0) return setError(UNKNOWN_REGISTER);
-    insn.embed(num << 4);
-    _scan += _regs.regNameLen(regName);
-    return setOK();
+    const RegName reg = RegI8080::parseRegName(_scan);
+    if (!RegI8080::isStackReg(reg)) return setError(UNKNOWN_REGISTER);
+    insn.embed(RegI8080::encodeStackReg(reg));
+    _scan += RegI8080::regNameLen(reg);
+    return OK;
 }
 
 Error AsmI8080::encodeIndexReg(InsnI8080 &insn) {
-    const RegName regName = _regs.parseIndexReg(_scan);
-    const int8_t num = _regs.encodeIndexReg(regName);
-    if (num < 0) return setError(UNKNOWN_REGISTER);
-    insn.embed(num << 4);
-    _scan += _regs.regNameLen(regName);
+    const RegName reg = RegI8080::parseRegName(_scan);
+    if (!RegI8080::isIndexReg(reg)) return setError(UNKNOWN_REGISTER);
+    insn.embed(RegI8080::encodeIndexReg(reg));
+    _scan += RegI8080::regNameLen(reg);
     return setOK();
 }
 
 Error AsmI8080::encodeDataReg(InsnI8080 &insn) {
-    const RegName regName = _regs.parseDataReg(_scan);
-    const int8_t num = _regs.encodeDataReg(regName);
-    if (num < 0) return setError(UNKNOWN_REGISTER);
+    const RegName reg = RegI8080::parseRegName(_scan);
+    if (!RegI8080::isDataReg(reg)) return setError(UNKNOWN_REGISTER);
+    const uint8_t num = RegI8080::encodeDataReg(reg);
     if (insn.insnFormat() == DATA_REG)
         insn.embed(num << 3);
     if (insn.insnFormat() == LOW_DATA_REG)
         insn.embed(num);
-    _scan += _regs.regNameLen(regName);
-    return setOK();
+    _scan += RegI8080::regNameLen(reg);
+    return OK;
 }
 
 Error AsmI8080::encodeDataDataReg(InsnI8080 &insn) {
     const char *p = _scan;
-    const RegName dstReg = _regs.parseDataReg(p);
-    if (dstReg == REG_UNDEF)
-        return setError(UNKNOWN_REGISTER);
-    p = skipSpaces(p + _regs.regNameLen(dstReg));
+    const RegName dst = RegI8080::parseRegName(p);
+    if (!RegI8080::isDataReg(dst)) return setError(UNKNOWN_REGISTER);
+    const uint8_t dstNum = RegI8080::encodeDataReg(dst);
+    p = skipSpaces(p + RegI8080::regNameLen(dst));
     if (*p != ',') return setError(MISSING_COMMA);
     p = skipSpaces(p + 1);
-    const RegName srcReg = _regs.parseDataReg(p);
-    if (srcReg == REG_UNDEF) return setError(UNKNOWN_REGISTER);
-    _scan = p + _regs.regNameLen(srcReg);
+    const RegName src = RegI8080::parseRegName(p);
+    if (!RegI8080::isDataReg(src)) return setError(UNKNOWN_REGISTER);
+    const uint8_t srcNum = RegI8080::encodeDataReg(src);
+    _scan = skipSpaces(p + RegI8080::regNameLen(src));
 
-    const uint8_t dstNum = _regs.encodeDataReg(dstReg);
-    const uint8_t srcNum = _regs.encodeDataReg(srcReg);
     insn.embed(dstNum << 3);
     insn.embed(srcNum);
-    return setOK();
+    return OK;
 }
 
 Error AsmI8080::encodeVectorNo(InsnI8080 &insn) {
@@ -83,7 +79,7 @@ Error AsmI8080::encodeVectorNo(InsnI8080 &insn) {
     if (getOperand(vecNo)) return getError();
     if (vecNo >= 8) return setError(OVERFLOW_RANGE);
     insn.embed(vecNo << 3);
-    return setOK();
+    return OK;
 }
 
 Error AsmI8080::encodeImmediate(InsnI8080 &insn) {

--- a/src/asm_i8080.h
+++ b/src/asm_i8080.h
@@ -34,7 +34,6 @@ public:
 
 private:
     IntelValueParser _parser;
-    RegI8080 _regs;
 
     TableBase &getTable() const override { return TableI8080; }
 

--- a/src/asm_i8086.cpp
+++ b/src/asm_i8086.cpp
@@ -37,13 +37,13 @@ bool AsmI8086::parseStringInst(const char *scan, Operand &op) {
 
 const char *AsmI8086::parsePointerSize(const char *scan, Operand &op) {
     const char *p = scan;
-    const RegName reg = _regs.parseRegName(p);
+    const RegName reg = RegI8086::parseRegName(p);
     if (reg == REG_BYTE || reg == REG_WORD) {
-        p = skipSpaces(p + _regs.regNameLen(reg));
+        p = skipSpaces(p + RegI8086::regNameLen(reg));
         // Pointer size override
-        if (_regs.parseRegName(p) == REG_PTR) {
+        if (RegI8086::parseRegName(p) == REG_PTR) {
             op.ptr = reg;
-            return skipSpaces(p + _regs.regNameLen(REG_PTR));
+            return skipSpaces(p + RegI8086::regNameLen(REG_PTR));
         }
         setError(UNKNOWN_OPERAND);
         return nullptr;
@@ -53,9 +53,9 @@ const char *AsmI8086::parsePointerSize(const char *scan, Operand &op) {
 
 const char *AsmI8086::parseSegmentOverride(const char *scan, Operand &op) {
     const char *p = scan;
-    const RegName reg = _regs.parseRegName(p);
-    if (_regs.isSegmentReg(reg)) {
-        p = skipSpaces(p + _regs.regNameLen(reg));
+    const RegName reg = RegI8086::parseRegName(p);
+    if (RegI8086::isSegmentReg(reg)) {
+        p = skipSpaces(p + RegI8086::regNameLen(reg));
         // Segment Override
         if (*p == ':') {
             op.seg = reg;
@@ -67,10 +67,10 @@ const char *AsmI8086::parseSegmentOverride(const char *scan, Operand &op) {
 
 const char *AsmI8086::parseBaseRegister(const char *scan, Operand &op) {
     const char *p = scan;
-    const RegName reg = _regs.parseRegName(p);
+    const RegName reg = RegI8086::parseRegName(p);
     if (reg == REG_BX || reg == REG_BP) {
         op.reg = reg;
-        return skipSpaces(p + _regs.regNameLen(reg));
+        return skipSpaces(p + RegI8086::regNameLen(reg));
     }
     return scan;
 }
@@ -81,10 +81,10 @@ const char *AsmI8086::parseIndexRegister(const char *scan, Operand &op) {
         if (*p != '+') return scan;
         p = skipSpaces(p + 1);
     }
-    const RegName reg = _regs.parseRegName(p);
+    const RegName reg = RegI8086::parseRegName(p);
     if (reg == REG_SI || reg == REG_DI) {
         op.index = reg;
-        return skipSpaces(p + _regs.regNameLen(reg));
+        return skipSpaces(p + RegI8086::regNameLen(reg));
     }
     return scan;
 }
@@ -139,9 +139,9 @@ Error AsmI8086::parseOperand(Operand &op) {
     if (op.ptr != REG_UNDEF || op.seg != REG_UNDEF)
         return setError(UNKNOWN_OPERAND);
 
-    const RegName reg = _regs.parseRegName(p);
-    if (_regs.isGeneralReg(reg)) {
-        _scan = p + _regs.regNameLen(reg);
+    const RegName reg = RegI8086::parseRegName(p);
+    if (RegI8086::isGeneralReg(reg)) {
+        _scan = p + RegI8086::regNameLen(reg);
         op.reg = reg;
         switch (reg) {
         case REG_AL: op.mode = M_AL; break;
@@ -149,13 +149,13 @@ Error AsmI8086::parseOperand(Operand &op) {
         case REG_AX: op.mode = M_AX; break;
         case REG_DX: op.mode = M_DX; break;
         default:
-            op.mode = (_regs.regSize(reg) == SZ_BYTE) ? M_BREG : M_WREG;
+            op.mode = (RegI8086::generalRegSize(reg) == SZ_BYTE) ? M_BREG : M_WREG;
             break;
         }
         return OK;
     }
-    if (_regs.isSegmentReg(reg)) {
-        _scan = p + _regs.regNameLen(reg);
+    if (RegI8086::isSegmentReg(reg)) {
+        _scan = p + RegI8086::regNameLen(reg);
         op.reg = reg;
         op.mode = M_SREG;
         return OK;
@@ -212,7 +212,7 @@ Error AsmI8086::emitRelative(InsnI8086 &insn, const Operand &op, AddrMode mode) 
 }
 
 Error AsmI8086::emitRegister(InsnI8086 &insn, const Operand &op, OprPos pos) {
-    const uint8_t num = _regs.encodeRegNum(op.reg);
+    const uint8_t num = RegI8086::encodeRegNum(op.reg);
     switch (pos) {
     case P_OREG: insn.embed(num); break;
     case P_OSEG: insn.embed(num << 3); break;

--- a/src/asm_i8086.cpp
+++ b/src/asm_i8086.cpp
@@ -364,9 +364,9 @@ Error AsmI8086::encode(Insn &_insn) {
     InsnI8086 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
+    _scan = skipSpaces(endName);
 
     Operand dstOp, srcOp;
-    _scan = skipSpaces(endName);
     if (parseOperand(dstOp)) return getError();
     const char *p = skipSpaces(_scan);
     if (*p == ',') {

--- a/src/asm_i8086.h
+++ b/src/asm_i8086.h
@@ -34,7 +34,6 @@ public:
 
 private:
     IntelValueParser _parser;
-    RegI8086 _regs;
 
     TableBase &getTable() const override { return TableI8086; }
 

--- a/src/asm_ins8060.h
+++ b/src/asm_ins8060.h
@@ -37,7 +37,6 @@ private:
     protected:
         bool isCurrentOriginSymbol(char c) const override { return c == '$'; }
     } _parser;
-    RegIns8060 _regs;
 
     TableBase &getTable() const override { return TableIns8060; }
 

--- a/src/asm_ins8070.cpp
+++ b/src/asm_ins8070.cpp
@@ -65,7 +65,7 @@ Error AsmIns8070::emitGeneric(InsnIns8070 &insn, const Operand &op) {
     const Config::ptrdiff_t offset = static_cast<Config::uintptr_t>(op.val16);
     if (offset < -128 || offset >= 128)
         return setError(OVERFLOW_RANGE);
-    insn.embed(_regs.encodePointerReg(op.reg));
+    insn.embed(RegIns8070::encodePointerReg(op.reg));
     if (op.autoIndex) insn.embed(4);
     insn.emitOperand8(static_cast<uint8_t>(offset));
     return OK;
@@ -76,7 +76,7 @@ Error AsmIns8070::emitOperand(
     switch (format) {
     case OPR_PN:
     case OPR_BR:
-        insn.embed(_regs.encodePointerReg(op.reg));
+        insn.embed(RegIns8070::encodePointerReg(op.reg));
         break;
     case OPR_4:
         insn.embed(op.val16 & 0x0F);
@@ -109,9 +109,9 @@ Error AsmIns8070::parseOperand(Operand &op) {
         return OK;
     }
 
-    const RegName reg = _regs.parseRegister(p);
+    const RegName reg = RegIns8070::parseRegName(p);
     if (reg != REG_UNDEF) {
-        _scan = p + _regs.regNameLen(reg);
+        _scan = p + RegIns8070::regNameLen(reg);
         OprFormat opr;
         switch (reg) {
         case REG_A:  opr = OPR_A;  break;
@@ -143,11 +143,11 @@ Error AsmIns8070::parseOperand(Operand &op) {
             autoIndex = true;
             p++;
         }
-        const RegName ptr = _regs.parsePointerReg(p);
-        if (ptr == REG_UNDEF) return setError(UNKNOWN_OPERAND);
+        const RegName ptr = RegIns8070::parseRegName(p);
+        if (!RegIns8070::isPointerReg(ptr)) setError(UNKNOWN_OPERAND);
         if (autoIndex && (ptr == REG_PC || ptr == REG_SP))
             return setError(REGISTER_NOT_ALLOWED);
-        _scan = p + _regs.regNameLen(ptr);
+        _scan = p + RegIns8070::regNameLen(ptr);
         op.reg = ptr;
         op.autoIndex = autoIndex;
         op.format = (autoIndex || ptr == REG_SP || ptr == REG_PC)

--- a/src/asm_mc6800.cpp
+++ b/src/asm_mc6800.cpp
@@ -115,9 +115,9 @@ Error AsmMc6800::encode(Insn &_insn) {
     InsnMc6800 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
+    _scan = skipSpaces(endName);
 
     Operand op1, op2, op3;
-    _scan = skipSpaces(endName);
     if (parseOperand(op1)) return getError();
     const char *p = skipSpaces(_scan);
     if (*p == ',') {

--- a/src/asm_mc6800.cpp
+++ b/src/asm_mc6800.cpp
@@ -48,9 +48,9 @@ Error AsmMc6800::parseOperand(Operand &op) {
     p = skipSpaces(_scan);
     if (*p == ',') {
         p = skipSpaces(p + 1);
-        const RegName reg = _regs.parseRegName(p);
+        const RegName reg = RegMc6800::parseRegName(p);
         if (reg != REG_UNDEF) {
-            _scan = p + _regs.regNameLen(reg);
+            _scan = p + RegMc6800::regNameLen(reg);
             op.mode = (reg == REG_Y) ? M_IDY : M_IDX;
             return OK;
         }

--- a/src/asm_mc6800.h
+++ b/src/asm_mc6800.h
@@ -34,7 +34,6 @@ public:
 
 private:
     MotoValueParser _parser;
-    RegMc6800 _regs;
 
     TableBase &getTable() const override { return TableMc6800; }
 

--- a/src/asm_mc68000.cpp
+++ b/src/asm_mc68000.cpp
@@ -417,9 +417,11 @@ Error AsmMc68000::encode(Insn &_insn) {
         p = skipSpaces(_scan);
     }
     if (!endOfLine(p)) return setError(GARBAGE_AT_END);
+
     insn.setAddrMode(srcOp.mode, dstOp.mode);
     if (TableMc68000.searchName(insn))
         return setError(TableMc68000.getError());
+
     const AddrMode src = insn.srcMode();
     const AddrMode dst = insn.dstMode();
     if (src == M_MULT) srcOp.fixupMultiRegister();

--- a/src/asm_mc68000.cpp
+++ b/src/asm_mc68000.cpp
@@ -22,30 +22,6 @@
 namespace libasm {
 namespace mc68000 {
 
-static const char *parseSize(const char *line, OprSize &osize) {
-    const char *p = line;
-    if (*p++ != '.') {
-        osize = SZ_NONE;
-        return line;
-    }
-    const char c = toupper(*p++);
-    if (c == 'B') {
-        osize = SZ_BYTE;
-    } else if (c == 'W') {
-        osize = SZ_WORD;
-    } else if (c == 'L') {
-        osize = SZ_LONG;
-    } else {
-        osize = SZ_ERROR;
-        return line;
-    }
-    if (isalnum(*p) || *p == '_') {
-        osize = SZ_ERROR;
-        return line;
-    }
-    return p;
-}
-
 static int8_t modePos(OprPos pos) {
     switch (pos) {
     case OP_10: return 3;
@@ -95,8 +71,8 @@ Error AsmMc68000::emitBriefExtension(
     InsnMc68000 &insn, RegName index, OprSize size, Config::ptrdiff_t disp) {
     if (disp < -0x80 || disp > 0x80) return setError(OVERFLOW_RANGE);
     uint16_t ext = static_cast<uint8_t>(disp);
-    ext |= RegMc68000::encodeRegNo(index) << 12;
-    if (RegMc68000::isAreg(index)) ext |= (1 << 15);
+    ext |= RegMc68000::encodeGeneralRegNo(index) << 12;
+    if (RegMc68000::isAddrReg(index)) ext |= (1 << 15);
     if (size == SZ_LONG) ext |= (1 << 11);
     insn.emitOperand16(ext);
     return OK;
@@ -251,7 +227,7 @@ static uint16_t reverseBits(uint16_t bits) {
 
 void AsmMc68000::Operand::fixupMultiRegister() {
     if (mode == M_DREG || mode == M_AREG) {
-        val32 = (1 << RegMc68000::encodeRegPos(reg));
+        val32 = (1 << RegMc68000::encodeGeneralRegPos(reg));
         mode = M_MULT;
     }
 }
@@ -261,17 +237,17 @@ Error AsmMc68000::parseMoveMultiRegList(Operand &opr) {
     Error error = OK;
     for (;;) {
         RegName start = RegMc68000::parseRegName(p);
-        if (!RegMc68000::isADreg(start))
+        if (!RegMc68000::isGeneralReg(start))
             return opr.setError(REGISTER_NOT_ALLOWED);
         p = skipSpaces(p + RegMc68000::regNameLen(start));
-        uint8_t s = RegMc68000::encodeRegPos(start);
+        uint8_t s = RegMc68000::encodeGeneralRegPos(start);
         uint8_t e = s;
         if (*p == '-') {
             p = skipSpaces(p + 1);
             RegName last = RegMc68000::parseRegName(p);
-            if (!RegMc68000::isADreg(start))
+            if (!RegMc68000::isGeneralReg(start))
                 return opr.setError(REGISTER_NOT_ALLOWED);
-            e = RegMc68000::encodeRegPos(last);
+            e = RegMc68000::encodeGeneralRegPos(last);
             p = skipSpaces(p + RegMc68000::regNameLen(last));
         }
         if (s > e) return opr.setError(UNKNOWN_OPERAND);
@@ -304,7 +280,7 @@ Error AsmMc68000::parseOperand(Operand &op) {
     if (*p == '(') {
         p = skipSpaces(p + 1);
         op.reg = RegMc68000::parseRegName(p);
-        if (RegMc68000::isAreg(op.reg)) {
+        if (RegMc68000::isAddrReg(op.reg)) {
             p += RegMc68000::regNameLen(op.reg);
             p = skipSpaces(p);
             if (*p++ != ')')
@@ -323,8 +299,9 @@ Error AsmMc68000::parseOperand(Operand &op) {
         op.setErrorIf(getError());
         p = skipSpaces(_scan);
         if (*p == ')') {
-            OprSize size;
-            p = parseSize(p + 1, size);
+            p++;
+            const OprSize size = RegMc68000::parseSize(p);
+            p += RegMc68000::sizeNameLen(size);
             if ((op.val32 & 0xFF8000) == 0xFF8000) op.val32 |= 0xFFFF0000;
             if (size == SZ_NONE) {
                 op.mode = (op.val32 >= 0xFFFF8000 || op.val32 < 0x8000)
@@ -342,7 +319,7 @@ Error AsmMc68000::parseOperand(Operand &op) {
         if (*p == ',') {
             p = skipSpaces(p + 1);
             op.reg = RegMc68000::parseRegName(p);
-            if (!RegMc68000::isAreg(op.reg) && op.reg != REG_PC)
+            if (!RegMc68000::isAddrReg(op.reg) && op.reg != REG_PC)
                 return setError(REGISTER_NOT_ALLOWED);
             p += RegMc68000::regNameLen(op.reg);
             p = skipSpaces(p);
@@ -354,10 +331,11 @@ Error AsmMc68000::parseOperand(Operand &op) {
             if (*p != ',') return setError(MISSING_COMMA);
             p = skipSpaces(p + 1);
             op.indexReg = RegMc68000::parseRegName(p);
-            if (!RegMc68000::isADreg(op.indexReg))
+            if (!RegMc68000::isGeneralReg(op.indexReg))
                 return setError(UNKNOWN_OPERAND);
             p += RegMc68000::regNameLen(op.indexReg);
-            p = skipSpaces(parseSize(p, op.indexSize));
+            op.indexSize = RegMc68000::parseSize(p);
+            p = skipSpaces(p + RegMc68000::sizeNameLen(op.indexSize));
             if (op.indexSize == SZ_ERROR) return setError(UNKNOWN_OPERAND);
             if (op.indexSize == SZ_NONE) op.indexSize = SZ_WORD;
             if (*p++ != ')') return setError(MISSING_CLOSING_PAREN);
@@ -372,11 +350,11 @@ Error AsmMc68000::parseOperand(Operand &op) {
     if (op.reg != REG_UNDEF) {
         p += RegMc68000::regNameLen(op.reg);
         p = skipSpaces(p);
-        if ((*p == '/' || *p == '-') && RegMc68000::isADreg(op.reg))
+        if ((*p == '/' || *p == '-') && RegMc68000::isGeneralReg(op.reg))
             return parseMoveMultiRegList(op);
-        if (RegMc68000::isAreg(op.reg)) {
+        if (RegMc68000::isAddrReg(op.reg)) {
             op.mode = M_AREG;
-        } else if (RegMc68000::isDreg(op.reg)) {
+        } else if (RegMc68000::isDataReg(op.reg)) {
             op.mode = M_DREG;
         } else if (op.reg == REG_USP) {
             op.mode = M_USP;
@@ -400,9 +378,9 @@ Error AsmMc68000::encode(Insn &_insn) {
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
 
-    OprSize isize;
-    const char *endSize = parseSize(endName, isize);
+    const OprSize isize = RegMc68000::parseSize(endName);
     if (isize == SZ_ERROR) return setError(ILLEGAL_SIZE);
+    const char *endSize = endName + RegMc68000::sizeNameLen(isize);
     insn.setOprSize(isize);
 
     _scan = skipSpaces(endSize);

--- a/src/asm_mc6809.cpp
+++ b/src/asm_mc6809.cpp
@@ -86,11 +86,11 @@ Error AsmMc6809::encodeIndexed(
     InsnMc6809 &insn, Operand &op, bool emitInsn) {
     PostSpec spec;
     if (op.mode == REG_REG) {
-        if (!_regs.isIndexedBase(op.base)) return setError(UNKNOWN_OPERAND);
+        if (!RegMc6809::isIndexedBase(op.base)) return setError(UNKNOWN_OPERAND);
         if (op.index == REG_0) {
             op.index = REG_UNDEF;
             op.sub = DISP_IDX;
-        } else if (_regs.isIndexReg(op.index)) {
+        } else if (RegMc6809::isIndexReg(op.index)) {
             op.sub = ACCM_IDX;
         } else {
             return setError(REGISTER_NOT_ALLOWED);
@@ -124,7 +124,7 @@ Error AsmMc6809::encodeIndexed(
     if (TableMc6809.searchPostSpec(spec, post))
         return setError(UNKNOWN_OPERAND);
     if (spec.base == REG_X)
-        post |= (_regs.encodeBaseReg(op.base) << 5);
+        post |= (RegMc6809::encodeBaseReg(op.base) << 5);
     if (spec.mode == DISP_IDX && spec.size == 5)
         post |= static_cast<uint8_t>(disp & 0x1F);
     if (emitInsn) insn.emitInsn();
@@ -137,14 +137,15 @@ Error AsmMc6809::encodeIndexed(
 Error AsmMc6809::encodeRegisters(InsnMc6809 &insn, const Operand &op) {
     const RegName reg1 = op.mode == REG_BIT ? op.base : op.index;
     const RegName reg2 = op.mode == REG_BIT ? REG_0 : op.base;
-    const int8_t num1 = _regs.encodeDataReg(reg1);
-    const int8_t num2 = _regs.encodeDataReg(reg2);
-    if (num1 < 0 || num2 < 0) return setError(UNKNOWN_REGISTER);
-    const RegSize size1 = _regs.regSize(reg1);
-    const RegSize size2 = _regs.regSize(reg2);
+    if (!RegMc6809::isDataReg(reg1) || !RegMc6809::isDataReg(reg2))
+        return setError(UNKNOWN_REGISTER);
+    const RegSize size1 = RegMc6809::regSize(reg1);
+    const RegSize size2 = RegMc6809::regSize(reg2);
     if (size1 != SZ_NONE && size2 != SZ_NONE && size1 != size2)
         return setError(ILLEGAL_SIZE);
     insn.emitInsn();
+    const uint8_t num1 = RegMc6809::encodeDataReg(reg1);
+    const uint8_t num2 = RegMc6809::encodeDataReg(reg2);
     insn.emitByte((num1 << 4) | num2);
     return setOK();
 }
@@ -167,7 +168,7 @@ Error AsmMc6809::encodePushPull(InsnMc6809 &insn, const Operand &op) {
             stack = reg;
             if (reg == REG_S) reg = REG_U;
         }
-        uint8_t bit = _regs.encodeStackReg(reg, false);
+        uint8_t bit = RegMc6809::encodeStackReg(reg, false);
         if (bit == 0) return setError(REGISTER_NOT_ALLOWED);
         post = bit;
         reg = op.base;
@@ -176,7 +177,7 @@ Error AsmMc6809::encodePushPull(InsnMc6809 &insn, const Operand &op) {
             if (stack != reg) return setError(REGISTER_NOT_ALLOWED);
             if (reg == REG_S) reg = REG_U;
         }
-        bit = _regs.encodeStackReg(reg, false);
+        bit = RegMc6809::encodeStackReg(reg, false);
         if (bit == 0) return setError(REGISTER_NOT_ALLOWED);
         if (post & bit) return setError(DUPLICATE_REGISTER);
         post |= bit;
@@ -195,7 +196,7 @@ Error AsmMc6809::encodeBitOperation(
     InsnMc6809 &insn, const Operand &op, const Operand &extra) {
     const uint8_t opbit = op.extra;
     const uint8_t exbit = extra.extra;
-    const uint8_t post = (_regs.encodeBitOpReg(op.base) << 6)
+    const uint8_t post = (RegMc6809::encodeBitOpReg(op.base) << 6)
         | (exbit << 3) | opbit;
     insn.emitInsn();
     insn.emitByte(post);
@@ -212,18 +213,18 @@ Error AsmMc6809::encodeTransferMemory(
     } else if (op.mode == REG_TFM && extra.mode == REGLIST) {
         if (op.extra != '+') return setError(UNKNOWN_OPERAND);
         if (extra.extra != 1) return setError(UNKNOWN_OPERAND);
-        if (!_regs.isTfmBaseReg(extra.index)) return setError(OPERAND_NOT_ALLOWED);
+        if (!RegMc6809::isTfmBaseReg(extra.index)) return setError(OPERAND_NOT_ALLOWED);
         mode = 2;
     } else if (op.mode == REGLIST && extra.mode == REG_TFM) {
         if (op.extra != 1) return setError(UNKNOWN_OPERAND);
-        if (!_regs.isTfmBaseReg(op.index)) return setError(OPERAND_NOT_ALLOWED);
+        if (!RegMc6809::isTfmBaseReg(op.index)) return setError(OPERAND_NOT_ALLOWED);
         if (extra.extra != '+') return setError(UNKNOWN_OPERAND);
         mode = 3;
     } else return setError(UNKNOWN_OPERAND);
 
     insn.embed(mode);
-    const uint8_t post = (_regs.encodeTfmBaseReg(op.index) << 4)
-        | _regs.encodeTfmBaseReg(extra.index);
+    const uint8_t post = (RegMc6809::encodeTfmBaseReg(op.index) << 4)
+        | RegMc6809::encodeTfmBaseReg(extra.index);
     insn.emitInsn();
     insn.emitByte(post);
     return OK;
@@ -238,9 +239,9 @@ bool AsmMc6809::parsePointerMode(Operand &op, const char *p, bool indir) {
             p++; autoIndex = -2;
         }
     }
-    const RegName reg = _regs.parseRegName(p);
-    if (!_regs.isBaseReg(reg)) return false;
-    p += _regs.regNameLen(reg);
+    const RegName reg = RegMc6809::parseRegName(p);
+    if (!RegMc6809::isBaseReg(reg)) return false;
+    p += RegMc6809::regNameLen(reg);
     if (autoIndex == 0 && *p == '+') {
         p++; autoIndex = 1;
         if (*p == '+') {
@@ -266,9 +267,9 @@ bool AsmMc6809::parsePointerMode(Operand &op, const char *p, bool indir) {
 
 bool AsmMc6809::parseIndexedMode(Operand &op, const char *p, bool indir) {
     p = skipSpaces(p);
-    const RegName base = _regs.parseRegName(p);
-    if (!_regs.isIndexedBase(base)) return false;
-    p = skipSpaces(p + _regs.regNameLen(base));
+    const RegName base = RegMc6809::parseRegName(p);
+    if (!RegMc6809::isIndexedBase(base)) return false;
+    p = skipSpaces(p + RegMc6809::regNameLen(base));
     if (indir) {
         if (*p == ']') {
             p++;
@@ -294,7 +295,7 @@ bool AsmMc6809::parseBitPosition(Operand &op, const char *p) {
         // bit position separator ',' can have spaces around it.
         p = skipSpaces(a + 1);
     } else return false;
-    const RegName reg = _regs.parseRegName(p);
+    const RegName reg = RegMc6809::parseRegName(p);
     if (reg != REG_0 && reg != REG_UNDEF) return false;
     const char *saved = _scan;
     _scan = p;
@@ -316,11 +317,11 @@ bool AsmMc6809::parseRegisterList(Operand &op, const char *p, bool indir) {
     uint8_t post = 0;
     const char *lastComma = p;
     while (true) {
-        RegName reg = _regs.parseRegName(p);
+        RegName reg = RegMc6809::parseRegName(p);
         if (reg == REG_UNDEF) return false;
-        p += _regs.regNameLen(reg);
+        p += RegMc6809::regNameLen(reg);
         if (*p == '+' || *p == '-') {
-            if (!_regs.isTfmBaseReg(reg)) {
+            if (!RegMc6809::isTfmBaseReg(reg)) {
                 op.setError(REGISTER_NOT_ALLOWED);
                 _scan = p + 1;
                 return true;
@@ -343,7 +344,7 @@ bool AsmMc6809::parseRegisterList(Operand &op, const char *p, bool indir) {
             if (stack != reg) push_pull = false;
             if (reg == REG_S) reg = REG_U;
         }
-        const uint8_t bit = _regs.encodeStackReg(reg, false);
+        const uint8_t bit = RegMc6809::encodeStackReg(reg, false);
         if (bit == 0) push_pull = false;
         if (post & bit) op.setError(DUPLICATE_REGISTER);
         post |= bit;
@@ -393,9 +394,9 @@ Error AsmMc6809::parseOperand(Operand &op) {
 
     if (parsePointerMode(op, p, indir))
         return getError();
-    const RegName reg = _regs.parseRegName(p);
-    if (!indir && _regs.isBitOpReg(reg)) {
-        const char *a = p + _regs.regNameLen(reg);
+    const RegName reg = RegMc6809::parseRegName(p);
+    if (!indir && RegMc6809::isBitOpReg(reg)) {
+        const char *a = p + RegMc6809::regNameLen(reg);
         if (parseBitPosition(op, a)) {
             op.mode = REG_BIT;
             op.base = reg;

--- a/src/asm_mc6809.h
+++ b/src/asm_mc6809.h
@@ -59,6 +59,7 @@ private:
               val32(0)
         {}
     };
+
     bool parsePointerMode(Operand &op, const char *scan, bool indir);
     bool parseIndexedMode(Operand &op, const char *scan, bool indir);
     bool parseBitRegister(Operand &op, const char *scan);
@@ -70,15 +71,15 @@ private:
     Error encodeRegisters(InsnMc6809 &insn, const Operand &op);
     Error encodeRelative(InsnMc6809 &insn, const Operand &op);
     Error encodeImmediate(
-            InsnMc6809 &insn, const Operand &op, Operand &extra);
+        InsnMc6809 &insn, const Operand &op, Operand &extra);
     Config::ptrdiff_t calculateDisplacement(
-            const InsnMc6809 &insn, const Operand &op) const;
+        const InsnMc6809 &insn, const Operand &op) const;
     Error encodeIndexed(
-            InsnMc6809 &insn, Operand &op, bool emitInsn = true);
+        InsnMc6809 &insn, Operand &op, bool emitInsn = true);
     Error encodeBitOperation(
-            InsnMc6809 &insn, const Operand &op, const Operand &extra);
+        InsnMc6809 &insn, const Operand &op, const Operand &extra);
     Error encodeTransferMemory(
-            InsnMc6809 &insn, const Operand &op, const Operand &extra);
+        InsnMc6809 &insn, const Operand &op, const Operand &extra);
 
     Error processPseudo(InsnMc6809 &insn);
     Error encode(Insn &insn) override;

--- a/src/asm_mc6809.h
+++ b/src/asm_mc6809.h
@@ -35,7 +35,6 @@ public:
 
 private:
     MotoValueParser _parser;
-    RegMc6809 _regs;
     uint8_t _direct_page;
 
     TableBase &getTable() const override { return TableMc6809; }

--- a/src/asm_mos6502.h
+++ b/src/asm_mos6502.h
@@ -37,7 +37,6 @@ public:
 
 private:
     MotoValueParser _parser;
-    RegMos6502 _regs;
     bool _long_acc = false;
     bool _long_idx = false;
 
@@ -56,7 +55,7 @@ private:
     Error parseOnOff(const char *line, bool &val);
     Error parseZeroOne(const char *line, bool &val);
     Error selectMode(
-        char size, Operand &op, AddrMode labs, AddrMode abs, AddrMode zp);
+        char size, Operand &op, AddrMode zp, AddrMode abs, AddrMode labs = IMPL);
     Error parseOperand(Operand &op, Operand &extra);
 
     Error encodeLongRelative(InsnMos6502 &insn, const Operand &op);
@@ -64,7 +63,6 @@ private:
     Error encodeZeroPageRelative(
         InsnMos6502 &insn, const Operand &op, const Operand &extra);
     Error processPseudo(InsnMos6502 &insn, const char *line);
-
     Error encode(Insn &insn) override;
 };
 

--- a/src/asm_ns32000.h
+++ b/src/asm_ns32000.h
@@ -35,7 +35,6 @@ public:
 
 private:
     ValueParser _parser;
-    RegNs32000 _regs;
 
     TableBase &getTable() const override { return TableNs32000; }
 

--- a/src/asm_tms9900.cpp
+++ b/src/asm_tms9900.cpp
@@ -49,10 +49,10 @@ Error AsmTms9900::encodeImmMod(InsnTms9900 &insn) {
 }
 
 Error AsmTms9900::encodeReg(InsnTms9900 &insn, bool emitInsn) {
-    RegName regName = _regs.parseRegName(_scan);
+    RegName regName = RegTms9900::parseRegName(_scan);
     if (regName == REG_UNDEF) return setError(UNKNOWN_OPERAND);
-    _scan += _regs.regNameLen(regName);
-    const uint16_t regNo = _regs.encodeRegNumber(regName);
+    _scan += RegTms9900::regNameLen(regName);
+    const uint16_t regNo = RegTms9900::encodeRegNumber(regName);
     switch (insn.addrMode()) {
     case REG:
     case REG_IMM:
@@ -71,7 +71,7 @@ Error AsmTms9900::encodeReg(InsnTms9900 &insn, bool emitInsn) {
 
 Error AsmTms9900::encodeCnt(InsnTms9900 &insn, bool acceptR0, bool accept16) {
     uint16_t count;
-    const RegName reg = _regs.parseRegName(_scan);
+    const RegName reg = RegTms9900::parseRegName(_scan);
     if (reg != REG_UNDEF) {
         if (reg != REG_R0 || !acceptR0) return setError(REGISTER_NOT_ALLOWED);
         _scan += 2;
@@ -115,16 +115,16 @@ Error AsmTms9900::encodeOpr(Config::opcode_t &oprMode, uint16_t &operand) {
     const char *p = _scan;
     RegName regName;
     uint8_t mode = 0;
-    if ((regName = _regs.parseRegName(p)) != REG_UNDEF) {
-        p += _regs.regNameLen(regName);
+    if ((regName = RegTms9900::parseRegName(p)) != REG_UNDEF) {
+        p += RegTms9900::regNameLen(regName);
         mode = 0;
         setOK();
     } else if (*p == '*') {
         p = skipSpaces(p + 1);
         mode = 1;
-        if ((regName = _regs.parseRegName(p)) == REG_UNDEF)
+        if ((regName = RegTms9900::parseRegName(p)) == REG_UNDEF)
             return setError(UNKNOWN_OPERAND);
-        p += _regs.regNameLen(regName);
+        p += RegTms9900::regNameLen(regName);
         if (*p == '+') {
             p++;
             mode = 3;
@@ -137,10 +137,10 @@ Error AsmTms9900::encodeOpr(Config::opcode_t &oprMode, uint16_t &operand) {
         p = skipSpaces(_scan);
         if (*p == '(') {
             p = skipSpaces(p + 1);
-            regName = _regs.parseRegName(p);
+            regName = RegTms9900::parseRegName(p);
             if (regName == REG_UNDEF) return setError(UNKNOWN_OPERAND);
             if (regName == REG_R0) return setError(REGISTER_NOT_ALLOWED);
-            p = skipSpaces(p + _regs.regNameLen(regName));
+            p = skipSpaces(p + RegTms9900::regNameLen(regName));
             if (*p != ')') return setError(MISSING_CLOSING_PAREN);
             p++;
         } else {
@@ -148,7 +148,7 @@ Error AsmTms9900::encodeOpr(Config::opcode_t &oprMode, uint16_t &operand) {
         }
     }
     _scan = p;
-    oprMode = (mode << 4) | _regs.encodeRegNumber(regName);
+    oprMode = (mode << 4) | RegTms9900::encodeRegNumber(regName);
     return OK;
 }
 
@@ -191,10 +191,10 @@ Error AsmTms9900::encodeDoubleWords(InsnTms9900 &insn) {
         if (dstOpr >= 16) return setError(ILLEGAL_BIT_NUMBER);
         dstMode = dstOpr;
     } else if (insn.addrMode() == DW_CNT_SRC) {
-        const RegName reg = _regs.parseRegName(_scan);
+        const RegName reg = RegTms9900::parseRegName(_scan);
         if (reg != REG_UNDEF) {
             if (reg != REG_R0) return setError(REGISTER_NOT_ALLOWED);
-            _scan += _regs.regNameLen(reg);
+            _scan += RegTms9900::regNameLen(reg);
             dstOpr = 0;
         } else if (getOperand(dstOpr)) {
             return getError();

--- a/src/asm_tms9900.cpp
+++ b/src/asm_tms9900.cpp
@@ -31,7 +31,7 @@ Error AsmTms9900::encodeImm(InsnTms9900 &insn, bool emitInsn) {
     uint16_t val;
     if (getOperand(val)) return getError();
     if (emitInsn) insn.emitInsn();
-    insn.emitOperand(val);
+    insn.emitOperand16(val);
     return OK;
 }
 
@@ -107,7 +107,7 @@ Error AsmTms9900::encodeOpr(
     if (emitInsn)
         insn.emitInsn();
     if (needsOperandWord(opCode))
-        insn.emitOperand(operand);
+        insn.emitOperand16(operand);
     return getError();
 }
 
@@ -211,9 +211,9 @@ Error AsmTms9900::encodeDoubleWords(InsnTms9900 &insn) {
     } else setError(INTERNAL_ERROR);
 
     insn.emitInsn();
-    insn.emitOperand(srcMode | (dstMode << 6));
-    if (needsOperandWord(srcMode)) insn.emitOperand(srcOpr);
-    if (needsOperandWord(dstMode)) insn.emitOperand(dstOpr);
+    insn.emitOperand16(srcMode | (dstMode << 6));
+    if (needsOperandWord(srcMode)) insn.emitOperand16(srcOpr);
+    if (needsOperandWord(dstMode)) insn.emitOperand16(dstOpr);
     return getError();
 }
 
@@ -221,6 +221,7 @@ Error AsmTms9900::encode(Insn &_insn) {
     InsnTms9900 insn(_insn);
     const char *endName = _parser.scanSymbol(_scan);
     insn.setName(_scan, endName);
+
     if (TableTms9900.searchName(insn))
         return setError(TableTms9900.getError());
     _scan = skipSpaces(endName);

--- a/src/asm_tms9900.h
+++ b/src/asm_tms9900.h
@@ -34,7 +34,6 @@ public:
 
 private:
     IntelValueParser _parser;
-    RegTms9900 _regs;
 
     TableBase &getTable() const override { return TableTms9900; }
 

--- a/src/asm_z8.h
+++ b/src/asm_z8.h
@@ -32,16 +32,20 @@ class AsmZ8
 public:
     ValueParser *getParser() override { return &_parser; }
 
-    void reset() override { _regs.setRegPointer(-1); }
-    bool setRegPointer(int16_t rp) { return _regs.setRegPointer(rp); }
-    bool setRegPointer0(int16_t rp) { return _regs.setRegPointer0(rp); }
-    bool setRegPointer1(int16_t rp) { return _regs.setRegPointer1(rp); }
+    void reset() override { setRegPointer(-1); }
+    bool setRegPointer(int16_t rp);
+    bool setRegPointer0(int16_t rp0);
+    bool setRegPointer1(int16_t rp1);
 
 private:
     IntelValueParser _parser;
     RegZ8 _regs;
+    int16_t _regPointer0;
+    int16_t _regPointer1;
 
     TableBase &getTable() const override { return TableZ8; }
+
+    bool isWorkReg(uint8_t regAddr) const;
 
     struct Operand : public ErrorReporter {
         AddrMode mode;

--- a/src/asm_z80.cpp
+++ b/src/asm_z80.cpp
@@ -144,7 +144,7 @@ Error AsmZ80::encodeIndexed(
 Error AsmZ80::encodeIndexedImmediate8(
     InsnZ80 &insn, const Operand &dst, const Operand &src) {
     Config::opcode_t opc = insn.opCode();
-    insn.setInsnCode(0, insn.prefixCode());
+    insn.setOpCode(insn.prefix());
     if (dst.format == IX_OFF)
         RegZ80::encodeIndexReg(insn, dst.reg);
     if (src.format == IX_OFF)

--- a/src/asm_z80.cpp
+++ b/src/asm_z80.cpp
@@ -264,7 +264,8 @@ Error AsmZ80::parseOperand(Operand &opr) {
     }
 
     // 'C' is either C-reg or C-condition
-    if (_regs.compareRegName(p, REG_C)) {
+    const RegName reg = RegZ80::parseRegName(p);
+    if (reg == REG_C) {
         _scan = p + RegZ80::regNameLen(REG_C);
         opr.reg = REG_C;
         opr.size = SZ_BYTE;
@@ -273,17 +274,15 @@ Error AsmZ80::parseOperand(Operand &opr) {
         return opr.setOK();
     }
 
-    CcName ccName = _regs.parseCc8Name(p);
-    if (ccName != CC_UNDEF) {
-        opr.format = COND_8;
-        if (_regs.parseCc4Name(p) != CC_UNDEF)
-            opr.format = COND_4;
-        opr.val = RegZ80::encodeCcName(ccName);
-        _scan = p + RegZ80::ccNameLen(ccName);
+    const CcName cc = RegZ80::parseCcName(p);
+    if (cc != CC_UNDEF) {
+        opr.format = RegZ80::isCc4Name(cc) ? COND_4 : COND_8;
+        opr.val = RegZ80::encodeCcName(cc);
+        _scan = p + RegZ80::ccNameLen(cc);
         return opr.setOK();
     }
 
-    opr.reg = _regs.parseRegister(p);
+    opr.reg = RegZ80::parseRegName(p);
     if (opr.reg != REG_UNDEF) {
         _scan = p + RegZ80::regNameLen(opr.reg);
         switch (opr.reg) {
@@ -302,12 +301,12 @@ Error AsmZ80::parseOperand(Operand &opr) {
         default:      opr.format = REG_8; break;
         }
         if (opr.size == SZ_NONE)
-            opr.size = RegZ80::registerSize(opr.reg);
+            opr.size = RegZ80::regSize(opr.reg);
         return opr.setOK();
     }
     if (*p == '(') {
         p = skipSpaces(p + 1);
-        opr.reg = _regs.parseRegister(p);
+        opr.reg = RegZ80::parseRegName(p);
         if (opr.reg == REG_UNDEF) {
             _scan = p;
             if (getOperand(opr.val)) return opr.setError(getError());

--- a/src/asm_z80.h
+++ b/src/asm_z80.h
@@ -34,7 +34,6 @@ public:
 
 private:
     IntelValueParser _parser;
-    RegZ80 _regs;
 
     TableBase &getTable() const override { return TableZ80; }
 

--- a/src/asm_z8000.cpp
+++ b/src/asm_z8000.cpp
@@ -477,6 +477,7 @@ Error AsmZ8000::encode(Insn &_insn) {
     insn.setAddrMode(dstOp.mode, srcOp.mode, ex1Op.mode, ex2Op.mode);
     if (TableZ8000.searchName(insn))
         return setError(TableZ8000.getError());
+
     const AddrMode dst = insn.dstMode();
     if (dst != M_NO) {
         if (emitOperand(insn, dst, dstOp, insn.dstField()))

--- a/src/asm_z8000.h
+++ b/src/asm_z8000.h
@@ -37,7 +37,6 @@ public:
 
 private:
     ValueParser _parser;
-    RegZ8000 _regs;
 
     TableBase &getTable() const override { return TableZ8000; }
 

--- a/src/dis_base.cpp
+++ b/src/dis_base.cpp
@@ -20,12 +20,13 @@ namespace libasm {
 
 Error Disassembler::decode(
     DisMemory &memory, Insn &insn, char *operands, SymbolTable *symtab) {
-    insn.resetAddress(memory.address());
     _symtab = symtab;
-    this->resetError();
     getFormatter().setUppercase(_uppercase);
     getRegister().setUppercase(_uppercase);
+
+    resetError();
     *operands = 0;
+    insn.resetAddress(memory.address());
     decode(memory, insn, operands);
     if (!_uppercase) insn.toLowerName();
     return getError();

--- a/src/dis_i8080.cpp
+++ b/src/dis_i8080.cpp
@@ -24,44 +24,11 @@ char *DisI8080::outRegister(char *out, RegName regName) {
     return _regs.outRegName(out, regName);
 }
 
-Error DisI8080::decodeImmediate8(
-    DisMemory& memory, InsnI8080 &insn, char *out) {
-    uint8_t val;
-    if (insn.readByte(memory, val)) return setError(NO_MEMORY);
-    if (insn.insnFormat() != NO_FORMAT) *out++ = ',';
-    outConstant(out, val);
-    return setOK();
-}
-
-Error DisI8080::decodeImmediate16(
-    DisMemory& memory, InsnI8080 &insn, char *out) {
-    uint16_t val;
-    if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
-    if (insn.insnFormat() != NO_FORMAT) *out++ = ',';
-    outConstant(out, val);
-    return setOK();
-}
-
-Error DisI8080::decodeDirect(
-    DisMemory &memory, InsnI8080& insn, char *out) {
-    Config::uintptr_t addr;
-    if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
-    outAddress(out, addr);
-    return setOK();
-}
-
-Error DisI8080::decodeIoaddr(
-    DisMemory &memory, InsnI8080& insn, char *out) {
-    uint8_t ioaddr;
-    if (insn.readByte(memory, ioaddr)) return setError(NO_MEMORY);
-    outAddress(out, ioaddr);
-    return setOK();
-}
-
 Error DisI8080::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnI8080 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
+    const Config::opcode_t opCode = insn.readByte(memory);
+    if (setError(insn)) return getError();
+
     insn.setOpCode(opCode);
     if (TableI8080.searchOpCode(insn))
         return setError(TableI8080.getError());
@@ -95,19 +62,24 @@ Error DisI8080::decode(DisMemory &memory, Insn &_insn, char *out) {
     }
 
     switch (insn.addrMode()) {
-    case INHR:
-        return setOK();
     case IMM8:
-        return decodeImmediate8(memory, insn, out);
+        if (insn.insnFormat() != NO_FORMAT) *out++ = ',';
+        outConstant(out, insn.readByte(memory));
+        break;
     case IMM16:
-        return decodeImmediate16(memory, insn, out);
+        if (insn.insnFormat() != NO_FORMAT) *out++ = ',';
+        outConstant(out, insn.readUint16(memory));
+        break;
     case DIRECT:
-        return decodeDirect(memory, insn, out);
+        outAddress(out, insn.readUint16(memory));
+        break;
     case IOADR:
-        return decodeIoaddr(memory, insn, out);
+        outAddress(out, insn.readByte(memory));
+        break;
     default:
-        return setError(INTERNAL_ERROR);
+        break;
     }
+    return setError(insn);
 }
 
 } // namespace i8080

--- a/src/dis_i8080.cpp
+++ b/src/dis_i8080.cpp
@@ -35,24 +35,24 @@ Error DisI8080::decode(DisMemory &memory, Insn &_insn, char *out) {
 
     switch (insn.insnFormat()) {
     case POINTER_REG:
-        out = outRegister(out, RegI8080::decodePointerReg((opCode >> 4) & 3));
+        out = outRegister(out, RegI8080::decodePointerReg(opCode >> 4));
         break;
     case STACK_REG:
-        out = outRegister(out, RegI8080::decodeStackReg((opCode >> 4) & 3));
+        out = outRegister(out, RegI8080::decodeStackReg(opCode >> 4));
         break;
     case INDEX_REG:
-        out = outRegister(out, RegI8080::decodeIndexReg((opCode >> 4) & 1));
+        out = outRegister(out, RegI8080::decodeIndexReg(opCode >> 4));
         break;
     case DATA_REG:
-        out = outRegister(out, RegI8080::decodeDataReg((opCode >> 3) & 7));
+        out = outRegister(out, RegI8080::decodeDataReg(opCode >> 3));
         break;
     case LOW_DATA_REG:
-        out = outRegister(out, RegI8080::decodeDataReg(opCode & 7));
+        out = outRegister(out, RegI8080::decodeDataReg(opCode));
         break;
     case DATA_DATA_REG:
-        out = outRegister(out, RegI8080::decodeDataReg((opCode >> 3) & 7));
+        out = outRegister(out, RegI8080::decodeDataReg(opCode >> 3));
         *out++ = ',';
-        out = outRegister(out, RegI8080::decodeDataReg(opCode & 7));
+        out = outRegister(out, RegI8080::decodeDataReg(opCode));
         break;
     case VECTOR_NO:
         out = outConstant(out, static_cast<uint8_t>((opCode >> 3) & 7));

--- a/src/dis_i8080.h
+++ b/src/dis_i8080.h
@@ -33,6 +33,7 @@ public:
     ValueFormatter &getFormatter() override { return _formatter; }
 
 private:
+//    InsnI8080 _insn;
     IntelValueFormatter _formatter;
     RegI8080 _regs;
 
@@ -41,10 +42,6 @@ private:
 
     char *outRegister(char *out, RegName regName);
 
-    Error decodeImmediate8(DisMemory &memory, InsnI8080 &insn, char *out);
-    Error decodeImmediate16(DisMemory &memory, InsnI8080 &insn, char *out);
-    Error decodeDirect(DisMemory &memory, InsnI8080 &insn, char *out);
-    Error decodeIoaddr(DisMemory &memory, InsnI8080 &insn, char *out);
     Error decode(DisMemory &memory, Insn &insn, char *out) override;
 };
 

--- a/src/dis_i8086.cpp
+++ b/src/dis_i8086.cpp
@@ -50,47 +50,32 @@ Error DisI8086::decodeRelative(
     DisMemory &memory, InsnI8086 &insn, char *out, AddrMode mode) {
     int16_t disp;
     if (mode == M_REL8) {
-        uint8_t disp8;
-        if (insn.readByte(memory, disp8)) return setError(NO_MEMORY);
-        disp = static_cast<int8_t>(disp8);
+        disp = static_cast<int8_t>(insn.readByte(memory));
     } else {
-        uint16_t disp16;
-        if (insn.readUint16(memory, disp16)) return setError(NO_MEMORY);
-        disp = static_cast<int16_t>(disp16);
+        disp = static_cast<int16_t>(insn.readUint16(memory));
     }
     const Config::uintptr_t target = insn.address() + insn.length() + disp;
     outRelativeAddr(out, target, insn.address(), mode == M_REL8 ? 8 : 16);
-    return OK;
+    return setError(insn);
 }
 
 Error DisI8086::decodeImmediate(
     DisMemory &memory, InsnI8086 &insn, char *out, AddrMode mode) {
     if (mode == M_IMM && insn.oprSize() == SZ_WORD) {
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-        outConstant(out, val16);
-        return OK;
+        outConstant(out, insn.readUint16(memory));
+    } else if ((mode == M_IMM && insn.oprSize() == SZ_BYTE) || mode == M_IOA) {
+        outConstant(out, insn.readByte(memory));
+    } else if (mode == M_IMM8) {
+        outConstant(out, insn.readByte(memory), -16);
+    } else {
+        // M_FAR
+        const uint16_t offset  = insn.readUint16(memory);
+        const uint16_t segment = insn.readUint16(memory);
+        out = outAddress(out, segment);
+        *out++ = ':';
+        outAddress(out, offset);
     }
-    if ((mode == M_IMM && insn.oprSize() == SZ_BYTE) || mode == M_IOA) {
-        uint8_t val8;
-        if (insn.readByte(memory, val8)) return setError(NO_MEMORY);
-        outConstant(out, val8);
-        return OK;
-    }
-    if (mode == M_IMM8) {
-        uint8_t val8;
-        if (insn.readByte(memory, val8)) return setError(NO_MEMORY);
-        outConstant(out, val8, -16);
-        return OK;
-    }
-    // M_FAR
-    uint16_t segment, offset;
-    if (insn.readUint16(memory, offset)) return setError(NO_MEMORY);
-    if (insn.readUint16(memory, segment)) return setError(NO_MEMORY);
-    out = outAddress(out, segment);
-    *out++ = ':';
-    outAddress(out, offset);
-    return OK;
+    return setError(insn);
 }
 
 static RegName getBaseReg(uint8_t mod, uint8_t r_m) {
@@ -174,21 +159,17 @@ Error DisI8086::outMemReg(
     out = outRegister(out, index, sep);
     if (index != REG_UNDEF) sep = '+';
     if (mod == 1) {
-        uint8_t disp;
-        if (insn.readByte(memory, disp)) return setError(NO_MEMORY);
-        const int8_t disp8 = static_cast<int8_t>(disp);
+        const int8_t disp8 = static_cast<int8_t>(insn.readByte(memory));
         if (disp8 >= 0) *out++ = sep;
         out = outConstant(out, disp8, 10);
     }
     if (mod == 2 || (mod == 0 && r_m == 6)) {
-        uint16_t disp;
-        if (insn.readUint16(memory, disp)) return setError(NO_MEMORY);
         if (sep) *out++ = sep;
-        out = outAddress(out, disp);
+        out = outAddress(out, insn.readUint16(memory));
     }
     *out++ = ']';
     *out = 0;
-    return OK;
+    return setError(insn);
 }
 
 Error DisI8086::decodeMemReg(
@@ -207,10 +188,9 @@ Error DisI8086::decodeMemReg(
 
 Error DisI8086::decodeRepeatStr(DisMemory &memory, InsnI8086 &rep, char *out) {
     if (_repeatHasStringInst) {
-        Config::opcode_t opc;
         Insn _istr;
         InsnI8086 istr(_istr);
-        if (rep.readByte(memory, opc)) return setError(NO_MEMORY);
+        const Config::opcode_t opc = rep.readByte(memory);
         istr.setOpCode(opc, 0);
         if (TableI8086.searchOpCode(istr))
             setError(TableI8086.getError());
@@ -287,25 +267,6 @@ static bool validSegOverride(const InsnI8086 &insn) {
         || validSegOverride(insn.srcMode(), mod);
 }
 
-Error DisI8086::readCodes(DisMemory &memory, InsnI8086 &insn) {
-    while (true) {
-        Config::opcode_t opCode;
-        if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
-        if (TableI8086.isSegmentPrefix(opCode)) {
-            if (insn.segment()) return setError(ILLEGAL_SEGMENT);
-            insn.setSegment(opCode);
-            continue;
-        }
-        Config::opcode_t firstByte = 0;
-        if (TableI8086.isFirstByte(opCode)) {
-            firstByte = opCode;
-            if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
-        }
-        insn.setOpCode(opCode, firstByte);
-        return OK;
-    }
-}
-
 Error DisI8086::decodeStringInst(
     DisMemory &memory, InsnI8086 &insn, char *out) {
     if (insn.segment()) {
@@ -333,13 +294,32 @@ Error DisI8086::decodeStringInst(
     return setOK();
 }
 
+Error DisI8086::readCodes(DisMemory &memory, InsnI8086 &insn) {
+    while (true) {
+        Config::opcode_t opCode = insn.readByte(memory);
+        if (TableI8086.isSegmentPrefix(opCode)) {
+            if (insn.segment()) return setError(ILLEGAL_SEGMENT);
+            insn.setSegment(opCode);
+            continue;
+        }
+        Config::opcode_t firstByte = 0;
+        if (TableI8086.isFirstByte(opCode)) {
+            firstByte = opCode;
+            opCode = insn.readByte(memory);
+        }
+        insn.setOpCode(opCode, firstByte);
+        return setError(insn);
+    }
+}
+
 Error DisI8086::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnI8086 insn(_insn);
     if (readCodes(memory, insn)) return getError();
     if (TableI8086.searchOpCode(insn))
         return setError(TableI8086.getError());
-    if (insn.readModReg(memory)) return setError(NO_MEMORY);
 
+    insn.readModReg(memory);
+    if (setError(insn)) return getError();
     if (!validSegOverride(insn)) return setError(ILLEGAL_SEGMENT);
 
     if (insn.stringInst())
@@ -348,6 +328,7 @@ Error DisI8086::decode(DisMemory &memory, Insn &_insn, char *out) {
         return getError();
     if (insn.srcMode() == M_NONE)
         return setOK();
+
     out += strlen(out);
     *out++ = ',';
     if (decodeOperand(memory, insn, out, insn.srcMode(), insn.srcPos()))

--- a/src/dis_ins8060.cpp
+++ b/src/dis_ins8060.cpp
@@ -31,17 +31,14 @@ Error DisIns8060::decodePntr(InsnIns8060 &insn, char *out) {
 
 Error DisIns8060::decodeImm8(
         DisMemory& memory, InsnIns8060 &insn, char *out) {
-    uint8_t val;
-    if (insn.readByte(memory, val)) return setError(NO_MEMORY);
-    outConstant(out, val);
-    return setOK();
+    outConstant(out, insn.readByte(memory));
+    return setError(insn);
 }
 
 Error DisIns8060::decodeIndx(
     DisMemory &memory, InsnIns8060& insn, char *out, bool hasMode) {
     const RegName reg = _regs.decodePointerReg(insn.opCode() & 3);
-    uint8_t opr;
-    if (insn.readByte(memory, opr)) return setError(NO_MEMORY);
+    const uint8_t opr = insn.readByte(memory);
     if (hasMode && (insn.opCode() & 4) != 0)
         *out++ = '@';
     if (reg == REG_PC && opr != 0x80) { // PC relative
@@ -60,31 +57,32 @@ Error DisIns8060::decodeIndx(
             target |= page;
             outAddress(out, target);
         }
-        return setOK();
-    }
-    if (opr == 0x80) {         // E(Pn)
-        out = outRegister(out, REG_E);
     } else {
-        const int8_t disp = static_cast<int8_t>(opr);
-        out = outConstant(out, disp, 10);
+        if (opr == 0x80) {         // E(Pn)
+            out = outRegister(out, REG_E);
+        } else {
+            const int8_t disp = static_cast<int8_t>(opr);
+            out = outConstant(out, disp, 10);
+        }
+        *out++ = '(';
+        out = outRegister(out, reg);
+        *out++ = ')';
+        *out = 0;
     }
-    *out++ = '(';
-    out = outRegister(out, reg);
-    *out++ = ')';
-    *out = 0;
-    return setOK();
+    return setError(insn);
 }
 
 Error DisIns8060::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnIns8060 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
+    const Config::opcode_t opCode = insn.readByte(memory);
+    if (setError(insn)) return getError();
     insn.setOpCode(opCode);
+
     if (TableIns8060.searchOpCode(insn))
         return setError(TableIns8060.getError());
 
     switch (insn.addrMode()) {
-    case INHR:
+    default:
         return setOK();
     case PNTR:
         return decodePntr(insn, out);
@@ -95,8 +93,6 @@ Error DisIns8060::decode(DisMemory &memory, Insn &_insn, char *out) {
         return decodeIndx(memory, insn, out, false);
     case INDX:
         return decodeIndx(memory, insn, out, true);
-    default:
-        return setError(INTERNAL_ERROR);
     }
 }
 

--- a/src/dis_ins8060.cpp
+++ b/src/dis_ins8060.cpp
@@ -25,7 +25,7 @@ char *DisIns8060::outRegister(char *out, RegName regName) {
 }
 
 Error DisIns8060::decodePntr(InsnIns8060 &insn, char *out) {
-    outRegister(out, _regs.decodePointerReg(insn.opCode() & 3));
+    outRegister(out, _regs.decodePointerReg(insn.opCode()));
     return setOK();
 }
 
@@ -37,7 +37,7 @@ Error DisIns8060::decodeImm8(
 
 Error DisIns8060::decodeIndx(
     DisMemory &memory, InsnIns8060& insn, char *out, bool hasMode) {
-    const RegName reg = _regs.decodePointerReg(insn.opCode() & 3);
+    const RegName reg = _regs.decodePointerReg(insn.opCode());
     const uint8_t opr = insn.readByte(memory);
     if (hasMode && (insn.opCode() & 4) != 0)
         *out++ = '@';

--- a/src/dis_ins8070.cpp
+++ b/src/dis_ins8070.cpp
@@ -31,7 +31,7 @@ char *DisIns8070::outOperand(char *out, OprFormat opr, uint8_t value) {
     case OPR_S:  return outRegister(out, REG_S);
     case OPR_EA: return outRegister(out, REG_EA);
     case OPR_PN: return outRegister(out, (value & 1) ? REG_P3 : REG_P2);
-    case OPR_BR: return outRegister(out, RegIns8070::decodePointerReg(value & 3));
+    case OPR_BR: return outRegister(out, RegIns8070::decodePointerReg(value));
     case OPR_T:  return outRegister(out, REG_T);
     case OPR_4:  return outConstant(out, static_cast<uint8_t>(value & 15), 10);
     default:     return out;
@@ -78,7 +78,7 @@ Error DisIns8070::decodeRelative(
         DisMemory &memory, InsnIns8070 &insn, char *out) {
     const Config::ptrdiff_t disp = static_cast<int8_t>(insn.readByte(memory));
     const OprFormat src = insn.srcOpr();
-    const RegName base = _regs.decodePointerReg(insn.opCode() & 3);
+    const RegName base = _regs.decodePointerReg(insn.opCode());
     if (insn.dstOpr() == OPR_RL
         || (src == OPR_GN && base == REG_PC)) {
         const uint8_t fetch = (insn.addrMode() == RELATIVE) ? 1 : 0;

--- a/src/dis_ins8070.cpp
+++ b/src/dis_ins8070.cpp
@@ -24,78 +24,61 @@ char *DisIns8070::outRegister(char *out, RegName regName) {
     return _regs.outRegName(out, regName);
 }
 
-bool DisIns8070::outOperand(char *out, OprFormat opr, uint8_t value) {
+char *DisIns8070::outOperand(char *out, OprFormat opr, uint8_t value) {
     switch (opr) {
-    case OPR_A: outRegister(out, REG_A); break;
-    case OPR_E: outRegister(out, REG_E); break;
-    case OPR_S: outRegister(out, REG_S); break;
-    case OPR_EA: outRegister(out, REG_EA); break;
-    case OPR_PN:
-        outRegister(out, (value & 1) ? REG_P3 : REG_P2);
-        break;
-    case OPR_BR:
-        switch (value & 3) {
-        case 0: outRegister(out, REG_PC); break;
-        case 1: outRegister(out, REG_SP); break;
-        case 2: outRegister(out, REG_P2); break;
-        case 3: outRegister(out, REG_P3); break;
-        }
-        break;
-    case OPR_T: outRegister(out, REG_T); break;
-    case OPR_4:
-        outConstant(out, static_cast<uint8_t>(value & 15), 10);
-        break;
-    case OPR_NO: break;
-    default:
-        return false;
+    case OPR_A:  return outRegister(out, REG_A);
+    case OPR_E:  return outRegister(out, REG_E);
+    case OPR_S:  return outRegister(out, REG_S);
+    case OPR_EA: return outRegister(out, REG_EA);
+    case OPR_PN: return outRegister(out, (value & 1) ? REG_P3 : REG_P2);
+    case OPR_BR: return outRegister(out, RegIns8070::decodePointerReg(value & 3));
+    case OPR_T:  return outRegister(out, REG_T);
+    case OPR_4:  return outConstant(out, static_cast<uint8_t>(value & 15), 10);
+    default:     return out;
     }
-    return true;
 }
 
 Error DisIns8070::decodeImplied(InsnIns8070 &insn, char *out) {
-    if (outOperand(out, insn.dstOpr(), insn.opCode())) {
-        out += strlen(out);
-        if (insn.srcOpr() != OPR_NO) {
-            *out++ = ',';
-            outOperand(out, insn.srcOpr(), insn.opCode());
-        }
-        return setOK();
+    out = outOperand(out, insn.dstOpr(), insn.opCode());
+    if (insn.srcOpr() != OPR_NO) {
+        *out++ = ',';
+        outOperand(out, insn.srcOpr(), insn.opCode());
     }
-    return setError(ILLEGAL_OPERAND);
+    return setOK();
 }
 
 Error DisIns8070::decodeImmediate(
     DisMemory &memory, InsnIns8070 &insn, char *out) {
-    outOperand(out, insn.dstOpr(), insn.opCode());
-    out += strlen(out);
+    out = outOperand(out, insn.dstOpr(), insn.opCode());
     *out++ = ',';
     *out++ = _immSym ? '#' : '=';
     if (insn.oprSize() == SZ_WORD)
         return decodeAbsolute(memory, insn, out);
 
-    uint8_t val;
-    if (insn.readByte(memory, val)) return setError(NO_MEMORY);
-    outConstant(out, val, 16);
-    return setOK();
+    outConstant(out, insn.readByte(memory));
+    return setError(insn);
 }
 
 Error DisIns8070::decodeAbsolute(
     DisMemory &memory, InsnIns8070 &insn, char *out) {
-    uint16_t val;
-    if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
     const uint8_t fetch = (insn.addrMode() == ABSOLUTE) ? 1 : 0;
-    const Config::uintptr_t target = val + fetch;
+    const Config::uintptr_t target = insn.readUint16(memory) + fetch;
     outAddress(out, target);
-    return setOK();
+    return setError(insn);
+}
+
+Error DisIns8070::decodeDirect(
+    DisMemory &memory, InsnIns8070 &insn, char *out) {
+    const Config::uintptr_t target = 0xFF00 | insn.readByte(memory);
+    outAddress(out, target);
+    return setError(insn);
 }
 
 Error DisIns8070::decodeRelative(
         DisMemory &memory, InsnIns8070 &insn, char *out) {
-    uint8_t val;
-    if (insn.readByte(memory, val)) return setError(NO_MEMORY);
-    const Config::ptrdiff_t disp = static_cast<int8_t>(val);
+    const Config::ptrdiff_t disp = static_cast<int8_t>(insn.readByte(memory));
     const OprFormat src = insn.srcOpr();
-    const RegName base = _regs.decodePointerReg(insn.opCode());
+    const RegName base = _regs.decodePointerReg(insn.opCode() & 3);
     if (insn.dstOpr() == OPR_RL
         || (src == OPR_GN && base == REG_PC)) {
         const uint8_t fetch = (insn.addrMode() == RELATIVE) ? 1 : 0;
@@ -114,37 +97,35 @@ Error DisIns8070::decodeRelative(
             outOperand(out, OPR_BR, insn.opCode());
         }
     }
-    return setOK();
+    return setError(insn);
 }
 
 Error DisIns8070::decodeGeneric(
     DisMemory &memory, InsnIns8070 &insn, char *out) {
     const uint8_t mode = insn.opCode() & 7;
-    if (mode == 4) return decodeImmediate(memory, insn, out);
-
-    outOperand(out, insn.dstOpr());
-    out += strlen(out);
-    *out++ = ',';
-    if (mode < 4) return decodeRelative(memory, insn, out);
-    if (mode >= 6) {
+    if (mode != 4) {
+       out = outOperand(out, insn.dstOpr());
+       *out++ = ',';
+    }
+    switch (mode) {
+    case 4:
+        return decodeImmediate(memory, insn, out);
+    case 5:
+        return decodeDirect(memory, insn, out);
+    case 6: case 7:
         *out++ = '@';
         return decodeRelative(memory, insn, out);
+    default:
+        return decodeRelative(memory, insn, out);
     }
-    if (mode == 5) {            // DIRECT
-        uint8_t val;
-        if (insn.readByte(memory, val)) return setError(NO_MEMORY);
-        const Config::uintptr_t addr = 0xFF00 | val;
-        outAddress(out, addr);
-        return setOK();
-    }
-    return UNKNOWN_INSTRUCTION;
 }
 
 Error DisIns8070::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnIns8070 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
+    const Config::opcode_t opCode = insn.readByte(memory);
+    if (setError(insn)) return getError();
     insn.setOpCode(opCode);
+
     if (TableIns8070.searchOpCode(insn))
         return setError(TableIns8070.getError());
 

--- a/src/dis_ins8070.h
+++ b/src/dis_ins8070.h
@@ -44,11 +44,12 @@ private:
     RegBase &getRegister() override { return _regs; }
 
     char *outRegister(char *out, RegName regName);
-    bool outOperand(char *out, OprFormat opr, uint8_t value = 0);
+    char *outOperand(char *out, OprFormat opr, uint8_t value = 0);
 
     Error decodeImplied(InsnIns8070 &insn, char *out);
     Error decodeImmediate(DisMemory &memory, InsnIns8070 &insn, char *out);
     Error decodeAbsolute(DisMemory &memory, InsnIns8070 &insn, char *out);
+    Error decodeDirect(DisMemory &memory, InsnIns8070 &insn, char *out);
     Error decodeRelative(DisMemory &memory, InsnIns8070 &insn, char *out);
     Error decodeGeneric(DisMemory &memory, InsnIns8070 &insn, char *out);
     Error decode(DisMemory &memory, Insn &insn, char *out) override;

--- a/src/dis_mc68000.cpp
+++ b/src/dis_mc68000.cpp
@@ -31,24 +31,13 @@ char *DisMc68000::outOprSize(char *out, OprSize size) {
 Error DisMc68000::decodeImmediateData(
     DisMemory &memory, InsnMc68000 &insn, char *out, OprSize size) {
     if (size == SZ_BYTE) {
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-        outConstant(out, static_cast<uint8_t>(val16));
-        return OK;
+        outConstant(out, static_cast<uint8_t>(insn.readUint16(memory)));
+    } else if (size == SZ_WORD) {
+        outConstant(out, insn.readUint16(memory));
+    } else if (size == SZ_LONG) {
+        outConstant(out, insn.readUint32(memory));
     }
-    if (size == SZ_WORD) {
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-        outConstant(out, val16);
-        return OK;
-    }
-    if (size == SZ_LONG) {
-        uint32_t val32;
-        if (insn.readUint32(memory, val32)) return setError(NO_MEMORY);
-        outConstant(out, val32);
-        return OK;
-    }
-    return setError(ILLEGAL_SIZE);
+    return setError(insn);
 }
 
 Error DisMc68000::decodeEffectiveAddr(
@@ -70,8 +59,7 @@ Error DisMc68000::decodeEffectiveAddr(
     *out++ = '(';
     if (mode == M_DISP || mode == M_PCDSP) {
         const RegName base = (mode == M_DISP) ? ea.reg : REG_PC;
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
+        const uint16_t val16 = insn.readUint16(memory);
         if (mode == M_PCDSP) {
             const Config::uintptr_t target =
                 insn.address() + 2 + static_cast<int16_t>(val16);
@@ -98,14 +86,9 @@ Error DisMc68000::decodeEffectiveAddr(
     if (mode == M_AWORD || mode == M_ALONG) {
         Config::uintptr_t target;
         if (mode == M_AWORD) {
-            uint16_t val16;
-            if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-            const int16_t signed16 = static_cast<int16_t>(val16);
-            target = static_cast<int32_t>(signed16);
+            target = static_cast<int16_t>(insn.readUint16(memory));
         } else {
-            uint32_t val32;
-            if (insn.readUint32(memory, val32)) return setError(NO_MEMORY);
-            target = val32;
+            target = insn.readUint32(memory);
         }
         if (ea.size == SZ_WORD && (target % 2) != 0)
             return setError(OPERAND_NOT_ALIGNED);
@@ -116,7 +99,7 @@ Error DisMc68000::decodeEffectiveAddr(
     if (mode == M_INDX || mode == M_PCIDX) {
         const RegName base = (mode == M_INDX) ? ea.reg : REG_PC;
         BriefExt ext;
-        if (insn.readUint16(memory, ext.word)) return setError(NO_MEMORY);
+        ext.word = insn.readUint16(memory);
         const uint8_t val8 = ext.disp();
         if (mode == M_PCIDX) {
             const Config::uintptr_t target =
@@ -142,7 +125,7 @@ Error DisMc68000::decodeEffectiveAddr(
     if (mode == M_ALONG) out = outOprSize(out, SZ_LONG);
     if (mode == M_PINC) *out++ = '+';
     *out = 0;
-    return setOK();
+    return setError(insn);
 }
 
 Error DisMc68000::decodeRelative(
@@ -151,13 +134,11 @@ Error DisMc68000::decodeRelative(
     if (rel8) {
         target += static_cast<int8_t>(rel8);
     } else {
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-        target += static_cast<int16_t>(val16);
+        target += static_cast<int16_t>(insn.readUint16(memory));
     }
     if (target % 2) return setError(OPERAND_NOT_ALIGNED);
     outRelativeAddr(out, target, insn.address(), rel8 ? 8 : 16);
-    return setOK();
+    return setError(insn);
 }
 
 static RegName decodeMoveMltReg(int8_t regno) {
@@ -382,9 +363,10 @@ static OprSize sizeVal(const InsnMc68000 &insn) {
 
 Error DisMc68000::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnMc68000 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readUint16(memory, opCode)) return setError(NO_MEMORY);
+    const Config::opcode_t opCode = insn.readUint16(memory);
+    if (setError(insn)) return getError();
     insn.setOpCode(opCode);
+
     if (TableMc68000.searchOpCode(insn))
         return setError(TableMc68000.getError());
 
@@ -402,15 +384,24 @@ Error DisMc68000::decode(DisMemory &memory, Insn &_insn, char *out) {
     const uint8_t dstReg = regVal(opCode, dstPos);
     if (checkOperand(dst, dstMode, dstReg, size))
         return getError();
+
     uint16_t opr16 = 0;
-    if (src == M_IMBIT || src == M_MULT || dst == M_MULT || dst == M_IMDSP) {
-        if (insn.readUint16(memory, opr16)) return setError(NO_MEMORY);
+    if (src == M_IMBIT || src == M_MULT || dst == M_MULT || dst == M_IMDSP)
+        opr16 = insn.readUint16(memory);
+
+    const InsnSize iSize = insn.insnSize();
+    const OprSize oSize = (iSize == ISZ_DATA) ? size : OprSize(iSize);
+    if (oSize != SZ_NONE) {
+        char suffix[4];
+        outOprSize(suffix, oSize);
+        for (const char *p = suffix; *p; p++)
+            insn.appendName(*p);
     }
-    if (insn.insnSize() != ISZ_NONE)
-        insn.appendOprSize(size, _regs);
+
     if (src == M_NONE) return setOK();
     if (decodeOperand(memory, insn, out, src, srcMode, srcReg, size, opr16))
         return getError();
+
     if (dst == M_NONE) return setOK();
     out += strlen(out);
     *out++ = ',';

--- a/src/dis_mc68000.cpp
+++ b/src/dis_mc68000.cpp
@@ -25,7 +25,12 @@ char *DisMc68000::outRegName(char *out, RegName regName) {
 }
 
 char *DisMc68000::outOprSize(char *out, OprSize size) {
-    return _regs.outOprSize(out, size);
+    const char suffix = _regs.sizeSuffix(size);
+    if (suffix) {
+        *out++ = '.';
+        *out++ = suffix;
+    }
+    return out;
 }
 
 Error DisMc68000::decodeImmediateData(
@@ -391,11 +396,10 @@ Error DisMc68000::decode(DisMemory &memory, Insn &_insn, char *out) {
 
     const InsnSize iSize = insn.insnSize();
     const OprSize oSize = (iSize == ISZ_DATA) ? size : OprSize(iSize);
-    if (oSize != SZ_NONE) {
-        char suffix[4];
-        outOprSize(suffix, oSize);
-        for (const char *p = suffix; *p; p++)
-            insn.appendName(*p);
+    const char suffix = _regs.sizeSuffix(oSize);
+    if (suffix) {
+        insn.appendName('.');
+        insn.appendName(suffix);
     }
 
     if (src == M_NONE) return setOK();

--- a/src/dis_mc6809.cpp
+++ b/src/dis_mc6809.cpp
@@ -86,7 +86,7 @@ Error DisMc6809::decodeIndexed(
         if (spec.size == -2) *out++ = '-';
     }
     if (spec.base == REG_X) {
-        const RegName base = _regs.decodeBaseReg((post >> 5) & 3);
+        const RegName base = _regs.decodeBaseReg(post >> 5);
         out = outRegister(out, base);
     } else if (spec.base != REG_UNDEF) {
         out = outRegister(out, spec.base);
@@ -150,12 +150,12 @@ Error DisMc6809::decodePushPull(
 Error DisMc6809::decodeRegisters(
     DisMemory &memory, InsnMc6809 &insn, char *out) {
     const uint8_t post = insn.readByte(memory);
+    const RegName dst = _regs.decodeDataReg(post);
     const RegName src = _regs.decodeDataReg(post >> 4);
-    const RegName dst = _regs.decodeDataReg(post & 0xf);
     if (src == REG_UNDEF || dst == REG_UNDEF)
         return setError(ILLEGAL_REGISTER);
-    const RegSize size1 = _regs.regSize(src);
     const RegSize size2 = _regs.regSize(dst);
+    const RegSize size1 = _regs.regSize(src);
     if (size1 != SZ_NONE && size2 != SZ_NONE && size1 != size2)
         return setError(ILLEGAL_SIZE);
     out = outRegister(out, src);
@@ -186,7 +186,7 @@ Error DisMc6809::decodeTransferMemory(
     const uint8_t post = insn.readByte(memory);
     if (insn.getError()) return setError(insn);
     const RegName src = _regs.decodeTfmBaseReg(post >> 4);
-    const RegName dst = _regs.decodeTfmBaseReg(post & 0xf);
+    const RegName dst = _regs.decodeTfmBaseReg(post);
     const uint8_t mode = insn.opCode() & 0x3;
     if (src == REG_UNDEF || dst == REG_UNDEF) return setError(ILLEGAL_REGISTER);
     out = outRegister(out, src);

--- a/src/dis_ns32000.cpp
+++ b/src/dis_ns32000.cpp
@@ -52,12 +52,9 @@ static bool isScaledIndex(uint8_t gen) {
 
 Error DisNs32000::readIndexByte(
         DisMemory &memory, InsnNs32000 &insn, AddrMode mode, OprPos pos) {
-    if (isGenMode(mode) && isScaledIndex(getOprField(insn, pos))) {
-        uint8_t data;
-        if (insn.readByte(memory, data)) return setError(NO_MEMORY);
-        insn.setIndexByte(data, pos);
-    }
-    return OK;
+    if (isGenMode(mode) && isScaledIndex(getOprField(insn, pos)))
+        insn.setIndexByte(insn.readByte(memory), pos);
+    return setError(insn);
 }
 
 char *DisNs32000::outDisplacement(char *out, const Displacement &disp) {
@@ -66,34 +63,30 @@ char *DisNs32000::outDisplacement(char *out, const Displacement &disp) {
 
 Error DisNs32000::readDisplacement(
         DisMemory &memory, InsnNs32000 &insn, Displacement &disp) {
-    uint8_t head;
-    if (insn.readByte(memory, head)) return setError(NO_MEMORY);
+    uint8_t head = insn.readByte(memory);
     // 0xxx|xxxx
     if ((head & 0x80) == 0) {
         if (head & 0x40) head |= 0x80;
         disp.val32 = static_cast<int8_t>(head);
         disp.bits = 7;
-        return OK;
+    } else {
+        int16_t val16 = static_cast<int8_t>(
+                (head & 0x20) ? (head | 0xC0) : (head & ~0xC0));
+        val16 <<= 8;
+        val16 |= insn.readByte(memory);
+        // 10xx|xxxx
+        if ((head & 0x40) == 0) {
+            disp.val32 = static_cast<int32_t>(val16);
+            disp.bits = 14;
+        } else {
+            // 1110|0000 is reserved
+            if (head == 0xE0) return setError(ILLEGAL_CONSTANT);
+            disp.val32 = (static_cast<int32_t>(val16) << 16)
+                | insn.readUint16(memory);
+            disp.bits = 30;
+        }
     }
-    int16_t val16 = static_cast<int8_t>(
-            (head & 0x20) ? (head | 0xC0) : (head & ~0xC0));
-    uint8_t val8;
-    if (insn.readByte(memory, val8)) return setError(NO_MEMORY);
-    val16 <<= 8;
-    val16 |= val8;
-    // 10xx|xxxx
-    if ((head & 0x40) == 0) {
-        disp.val32 = static_cast<int32_t>(val16);
-        disp.bits = 14;
-        return OK;
-    }
-    // 1110|0000 is reserved
-    if (head == 0xE0) return setError(ILLEGAL_CONSTANT);
-    uint16_t low16;
-    if (insn.readUint16(memory, low16)) return setError(NO_MEMORY);
-    disp.val32 = (static_cast<int32_t>(val16) << 16) | low16;
-    disp.bits = 30;
-    return OK;
+    return setError(insn);
 }
 
 Error DisNs32000::decodeLength(
@@ -126,60 +119,43 @@ static char *outComma(char *out) {
 Error DisNs32000::decodeBitField(
     DisMemory &memory, InsnNs32000 &insn, char *out, AddrMode mode) {
     if (mode == M_BFLEN) return OK;
-    uint8_t data;
-    if (insn.readByte(memory, data)) return setError(NO_MEMORY);
+    const uint8_t data = insn.readByte(memory);
     const uint8_t len = (data & 0x1F) + 1;
     const uint8_t off = (data >> 5);
     out = outConstant(out, off, 10);  // M_BFOFF
     out = outComma(out);
     outConstant(out, len, 10);  // M_BFLEN
-    return OK;
+    return setError(insn);
 }
 
 Error DisNs32000::decodeImmediate(
     DisMemory &memory, InsnNs32000 &insn, char *out, AddrMode mode) {
     const OprSize size = (mode == M_GENC) ? SZ_BYTE : insn.oprSize();
     switch (size) {
-    case SZ_BYTE: {
-        uint8_t val8;
-        if (insn.readByte(memory, val8)) return setError(NO_MEMORY);
-        outConstant(out, val8, mode == M_GENC ? -10 : 16);
+    case SZ_BYTE:
+        outConstant(out, insn.readByte(memory), mode == M_GENC ? -10 : 16);
         break;
-    }
-    case SZ_WORD: {
-        uint16_t val16;
-        if (insn.readUint16(memory, val16)) return setError(NO_MEMORY);
-        outConstant(out, val16);
+    case SZ_WORD:
+        outConstant(out, insn.readUint16(memory));
         break;
-    }
-    case SZ_LONG: {
-        uint32_t val32;
-        if (insn.readUint32(memory, val32)) return setError(NO_MEMORY);
-        outConstant(out, val32);
+    case SZ_LONG:
+        outConstant(out, insn.readUint32(memory));
         break;
-    }
 #ifdef ENABLE_FLOAT
-    case SZ_FLOAT: {
-        uint32_t val32;
-        if (insn.readUint32(memory, val32)) return setError(NO_MEMORY);
-        outConstant(out, val32);
+    case SZ_FLOAT:
+        outConstant(out, insn.readUint32(memory));
         break;
-    }
-    case SZ_DOUBLE: {
+    case SZ_DOUBLE:
         // TODO: double
-        uint32_t msb32, lsb32;
-        if (insn.readUint32(memory, msb32)) return setError(NO_MEMORY);
-        if (insn.readUint32(memory, lsb32)) return setError(NO_MEMORY);
-        out = outConstant(out, msb32);
+        out = outConstant(out, insn.readUint32(memory));
         *out++ = ':';
-        outConstant(out, lsb32);
+        outConstant(out, insn.readUint32(memory));
         break;
-    }
 #endif
     default:
         break;
     }
-    return setOK();
+    return setError(insn);
 }
 
 Error DisNs32000::decodeDisplacement(
@@ -245,8 +221,8 @@ Error DisNs32000::decodeStrOpt(
 
 Error DisNs32000::decodeRegisterList(
     DisMemory &memory, InsnNs32000 &insn, char *out, AddrMode mode) {
-    uint8_t list;
-    if (insn.readByte(memory, list)) return setError(NO_MEMORY);
+    uint8_t list = insn.readByte(memory);
+    if (setError(insn)) return getError();
     if (list == 0) return setError(OPCODE_HAS_NO_EFFECT);
     const uint8_t mask = (mode == M_POP) ? 0x80 : 0x01;
     *out++ = '[';
@@ -418,14 +394,14 @@ Error DisNs32000::decodeOperand(
 
 Error DisNs32000::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnNs32000 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
+    Config::opcode_t opCode = insn.readByte(memory);
     insn.setOpCode(opCode);
     if (TableNs32000.isPrefixCode(opCode)) {
         const Config::opcode_t prefix = opCode;
-        if (insn.readByte(memory, opCode)) return setError(NO_MEMORY);
+        opCode = insn.readByte(memory);
         insn.setOpCode(opCode, prefix);
     }
+    if (setError(insn)) return getError();
 
     if (TableNs32000.searchOpCode(insn, memory))
         return setError(TableNs32000.getError());

--- a/src/dis_ns32000.cpp
+++ b/src/dis_ns32000.cpp
@@ -184,38 +184,15 @@ Error DisNs32000::decodeRelative(
 
 Error DisNs32000::decodeConfig(
     const InsnNs32000 &insn, char *out, OprPos pos) {
-    const uint8_t config = getOprField(insn, pos);
-    *out++ = '[';
-    char sep = 0;
-    for (uint8_t mask = 0x01; mask < 0x10; mask <<= 1) {
-        if (config & mask) {
-            if (sep) *out++ = sep;
-            out = _regs.outConfigName(out, _regs.decodeConfigName(mask));
-            sep = ',';
-        }
-    }
-    *out++ = ']';
-    *out = 0;
+    const uint8_t configs = getOprField(insn, pos);
+    _regs.outConfigNames(out, configs);
     return OK;
 }
 
 Error DisNs32000::decodeStrOpt(
     const InsnNs32000 &insn, char *out, OprPos pos) {
-    const uint8_t strOpt = getOprField(insn, pos);
-    *out++ = '[';
-    char sep = 0;
-    StrOptName name = _regs.decodeStrOptName(strOpt & 0x02);
-    if (name != STROPT_UNDEF) {
-        out = _regs.outStrOptName(out, name);
-        sep = ',';
-    }
-    name = _regs.decodeStrOptName(strOpt & 0x0C);
-    if (name != STROPT_UNDEF) {
-        if (sep) *out++ = sep;
-        out = _regs.outStrOptName(out, name);
-    }
-    *out++ = ']';
-    *out = 0;
+    const uint8_t strOpts = getOprField(insn, pos);
+    _regs.outStrOptNames(out, strOpts);
     return OK;
 }
 

--- a/src/dis_tms9900.cpp
+++ b/src/dis_tms9900.cpp
@@ -26,10 +26,8 @@ Error DisTms9900::decodeOperand(
     const uint8_t mode = (opr >> 4) & 0x3;
     if (mode == 1 || mode == 3) *out++ = '*';
     if (mode == 2) {
-        uint16_t val;
-        if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
         *out++ = '@';
-        out = outConstant(out, val);
+        out = outConstant(out, insn.readUint16(memory));
         if (regno) {
             *out++ = '(';
             out = _regs.outRegName(out, regno);
@@ -41,15 +39,13 @@ Error DisTms9900::decodeOperand(
             *out++ = '+';
     }
     *out = 0;
-    return setOK();
+    return setError(insn);
 }
 
 Error DisTms9900::decodeImmediate(
     DisMemory& memory, InsnTms9900 &insn, char *out) {
-    uint16_t val;
-    if (insn.readUint16(memory, val)) return setError(NO_MEMORY);
-    outConstant(out, val, 16);
-    return setOK();
+    outConstant(out, insn.readUint16(memory));
+    return setError(insn);
 }
 
 Error DisTms9900::decodeRelative(InsnTms9900 &insn, char *out) {
@@ -66,14 +62,17 @@ static char *outComma(char *out) {
     return out;
 }
 
+static const char TEXT_MID[]  PROGMEM = "MID";
+
 Error DisTms9900::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnTms9900 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readUint16(memory, opCode)) return setError(NO_MEMORY);
+    Config::opcode_t opCode = insn.readUint16(memory);
+    if (setError(insn)) return getError();
+
     insn.setOpCode(opCode);
     if (TableTms9900.searchOpCode(insn)) {
     mid:
-        insn.setName("MID");
+        insn.setName_P(TEXT_MID);
         return setError(UNKNOWN_INSTRUCTION);
     }
 
@@ -103,8 +102,7 @@ Error DisTms9900::decode(DisMemory &memory, Insn &_insn, char *out) {
         else outConstant(out, count, 10);
         break;
     case DW_BIT_SRC:
-        if (insn.readUint16(memory, opCode))
-            return setError(NO_MEMORY);
+        opCode = insn.readUint16(memory);
         count = (opCode >> 6) & 0x0f;
         if ((opCode & 0xFC00) != 0x0000) goto mid;
         if ((opCode & 0x0030) == 0x0030) goto mid; // no auto increment mode
@@ -121,8 +119,7 @@ Error DisTms9900::decode(DisMemory &memory, Insn &_insn, char *out) {
         _regs.outRegName(out, opCode >> 6);
         break;
     case DW_CNT_SRC:
-        if (insn.readUint16(memory, opCode))
-            return setError(NO_MEMORY);
+        opCode = insn.readUint16(memory);
         if ((opCode & 0xFC00) != 0x4000) goto mid;
         if (decodeOperand(memory, insn, out, opCode))
             return getError();
@@ -142,8 +139,7 @@ Error DisTms9900::decode(DisMemory &memory, Insn &_insn, char *out) {
         outConstant(out, count, 10);
         break;
     case DW_DST_SRC:
-        if (insn.readUint16(memory, opCode))
-            return setError(NO_MEMORY);
+        opCode = insn.readUint16(memory);
         if ((opCode & 0xF000) != 0x4000) goto mid;
         /* Fall-through */
     case DST_SRC:
@@ -163,7 +159,7 @@ Error DisTms9900::decode(DisMemory &memory, Insn &_insn, char *out) {
     default:
         return setError(INTERNAL_ERROR);
     }
-    return setOK();
+    return setError(insn);
 }
 
 } // namespace tms9900

--- a/src/dis_z80.cpp
+++ b/src/dis_z80.cpp
@@ -56,10 +56,6 @@ char *DisZ80::outDataRegister(char *out, RegName regName) {
         : outRegister(out, regName);
 }
 
-char *DisZ80::outConditionName(char *out, Config::opcode_t cc, bool cc8) {
-    return cc8 ? _regs.outCc8Name(out, cc) : _regs.outCc4Name(out, cc);
-}
-
 Error DisZ80::decodeInherent(InsnZ80 &insn, char *out) {
     const Config::opcode_t opc = insn.opCode();
     switch (insn.dstFormat()) {
@@ -104,7 +100,7 @@ Error DisZ80::decodeInherent(InsnZ80 &insn, char *out) {
         out = outRegister(out, RegZ80::decodeIndexReg(insn));
         break;
     case COND_8:
-        out = outConditionName(out, (opc >> 3) & 7);
+        out = _regs.outCcName(out, _regs.decodeCcName((opc >> 3) & 7));
         break;
     case C_PTR:
         if (insn.srcFormat() == REG_8 && insn.insnFormat() == DST_FMT
@@ -247,7 +243,7 @@ Error DisZ80::decodeDirect(InsnZ80 &insn, char *out, Config::uintptr_t addr) {
         out = outRegister(out, REG_A);
         break;
     case COND_8:
-        out = outConditionName(out, (opc >> 3) & 7);
+        out = _regs.outCcName(out, _regs.decodeCcName((opc >> 3) & 7));
         break;
     case IMM_16:
         out = outAddress(out, addr);
@@ -321,7 +317,7 @@ Error DisZ80::decodeIoaddr(InsnZ80 &insn, char *out, uint8_t ioaddr) {
 Error DisZ80::decodeRelative(InsnZ80 &insn, char *out, int8_t delta) {
     if (insn.dstFormat() == COND_4) {
         const Config::opcode_t opc = insn.opCode();
-        out = outConditionName(out, (opc >> 3) & 3, false);
+        out = _regs.outCcName(out, _regs.decodeCcName((opc >> 3) & 3));
         *out++ = ',';
     }
     const Config::uintptr_t target = insn.address() + 2 + delta;

--- a/src/dis_z8000.cpp
+++ b/src/dis_z8000.cpp
@@ -44,8 +44,7 @@ Error DisZ8000::decodeImmediate(
     AddrMode mode, OprSize size) {
     *out++ = '#';
     if (mode == M_SCNT || mode == M_NCNT) {
-        uint16_t data;
-        if (insn.readUint16(memory, data)) return setError(NO_MEMORY);
+        uint16_t data = insn.readUint16(memory);
         if (size == SZ_BYTE && (data & 0xFF00) != 0)
             return setError(ILLEGAL_OPERAND);
         const int16_t count = (size == SZ_BYTE)
@@ -63,31 +62,16 @@ Error DisZ8000::decodeImmediate(
         if (size == SZ_LONG && data > 32)
             return setError(ILLEGAL_OPERAND);
         outConstant(out, data, 10);
-        return OK;
+    } else if (mode == M_IO) {
+        outAddress(out, insn.readUint16(memory));
+    } else if (size == SZ_BYTE) {
+        outConstant(out, static_cast<uint8_t>(insn.readUint16(memory)));
+    } else if (size == SZ_WORD) {
+        outConstant(out, insn.readUint16(memory));
+    } else if (size == SZ_LONG) {
+        outConstant(out, insn.readUint32(memory));
     }
-    if (mode == M_IO) {
-        uint16_t data;
-        if (insn.readUint16(memory, data)) return setError(NO_MEMORY);
-        outAddress(out, data);
-        return OK;
-    }
-    if (size == SZ_BYTE) {
-        uint16_t data;
-        if (insn.readUint16(memory, data)) return setError(NO_MEMORY);
-        outConstant(out, static_cast<uint8_t>(data), 16, true);
-        return OK;
-    }
-    if (size == SZ_WORD) {
-        uint16_t data;
-        if (insn.readUint16(memory, data)) return setError(NO_MEMORY);
-        outConstant(out, data, 16, true);
-        return OK;
-    }
-    // SZ_LONG
-    uint32_t data;
-    if (insn.readUint32(memory, data)) return setError(NO_MEMORY);
-    outConstant(out, data, 16, true);
-    return OK;
+    return setError(insn);
 }
 
 Error DisZ8000::decodeFlags(char *out, uint8_t flags) {
@@ -135,17 +119,15 @@ Error DisZ8000::decodeBaseAddressing(
     out += strlen(out);
     *out++ = '(';
     if (mode == M_BA) {
-        uint16_t disp;
-        if (insn.readUint16(memory, disp)) return setError(NO_MEMORY);
         *out++ = '#';
-        out = outConstant(out, disp, -16, true);
+        out = outConstant(out, insn.readUint16(memory), -16);
     } else { // M_BX
         if (decodeGeneralRegister(out, insn.post() >> 8, SZ_WORD)) return getError();
         out += strlen(out);
     }
     *out++ = ')';
     *out = 0;
-    return OK;
+    return setError(insn);
 }
 
 Error DisZ8000::decodeGenericAddressing(
@@ -178,30 +160,27 @@ Error DisZ8000::decodeGenericAddressing(
 
 Error DisZ8000::decodeDirectAddress(
     DisMemory &memory, InsnZ8000 &insn, char *out) {
-    uint16_t addr;
-    if (insn.readUint16(memory, addr)) return setError(NO_MEMORY);
+    const uint16_t addr = insn.readUint16(memory);
     if (TableZ8000.segmentedModel()) {
         const uint32_t seg = static_cast<uint32_t>(addr & 0x7F00) << 8;
         uint16_t off = static_cast<uint8_t>(addr);
         if (addr & 0x8000) {
             if (addr & 0x00FF) setError(ILLEGAL_OPERAND);
-            if (insn.readUint16(memory, off)) return setError(NO_MEMORY);
+            off = insn.readUint16(memory);
         }
         const uint32_t linear = seg | off;
         outAddress(out, linear, nullptr, false, addressWidth());
     } else {
         outAddress(out, addr, nullptr, false, addressWidth());
     }
-    return OK;
+    return setError(insn);
 }
 
 Error DisZ8000::decodeRelativeAddressing(
     DisMemory &memory, InsnZ8000 &insn, char *out, AddrMode mode) {
     int16_t delta = 0;
     if (mode == M_RA) {
-        uint16_t disp;
-        if (insn.readUint16(memory, disp)) return setError(NO_MEMORY);
-        delta = static_cast<int16_t>(disp);
+        delta = static_cast<int16_t>(insn.readUint16(memory));
     }
     if (mode == M_RA12) {
         uint16_t ra12 = insn.opCode() & 0xFFF;
@@ -222,7 +201,7 @@ Error DisZ8000::decodeRelativeAddressing(
     if (mode == M_RA12 && (target % 2) != 0)
         return setError(OPERAND_NOT_ALIGNED);
     outRelativeAddr(out, target, insn.address(), mode == M_RA ? 16 : 13);
-    return OK;
+    return setError(insn);
 }
 
 
@@ -332,12 +311,14 @@ char *DisZ8000::outComma(
 
 Error DisZ8000::decode(DisMemory &memory, Insn &_insn, char *out) {
     InsnZ8000 insn(_insn);
-    Config::opcode_t opCode;
-    if (insn.readUint16(memory, opCode)) return setError(NO_MEMORY);
+    const Config::opcode_t opCode = insn.readUint16(memory);
+    if (setError(insn)) return getError();
     insn.setOpCode(opCode);
+
     if (TableZ8000.searchOpCode(insn, memory))
         return setError(TableZ8000.getError());
     if (checkPostWord(insn)) return getError();
+
     const AddrMode dst = insn.dstMode();
     if (dst == M_NO) return setOK();
     if (decodeOperand(memory, insn, out, dst, insn.dstField()))

--- a/src/dis_z8000.cpp
+++ b/src/dis_z8000.cpp
@@ -243,7 +243,7 @@ Error DisZ8000::decodeOperand(
     case M_IR:
         if (num == 0) return setError(REGISTER_NOT_ALLOWED);
         return decodeGeneralRegister(out, num, SZ_ADDR, true);
-    case M_INTT:
+    case M_INTR:
         num &= 3;
         if (num == 3) return setError(OPCODE_HAS_NO_EFFECT);
         _regs.outIntrNames(out, num);

--- a/src/entry_mc6809.h
+++ b/src/entry_mc6809.h
@@ -58,23 +58,23 @@ struct Entry {
     const uint8_t flags;
     const char *name;
 
-    static inline AddrMode _addrMode(uint8_t flags) {
-        return AddrMode((flags >> addrMode_gp) & addrMode_gm);
+    static inline AddrMode _mode1(uint8_t flags) {
+        return AddrMode((flags >> op1_gp) & mode_gm);
     }
 
-    static inline AddrMode _extraMode(uint8_t flags) {
-        return AddrMode((flags >> extraMode_gp) & addrMode_gm);
+    static inline AddrMode _mode2(uint8_t flags) {
+        return AddrMode((flags >> op2_gp) & mode_gm);
     }
 
-    static constexpr uint8_t _flags(AddrMode mode, AddrMode extra) {
-        return (static_cast<uint8_t>(mode) << addrMode_gp)
-            | (static_cast<uint8_t>(extra) << extraMode_gp);
+    static constexpr uint8_t _flags(AddrMode op1, AddrMode op2) {
+        return (static_cast<uint8_t>(op1) << op1_gp)
+            | (static_cast<uint8_t>(op2) << op2_gp);
     }
 
 private:
-    static constexpr uint8_t addrMode_gm = 0xf;
-    static constexpr int addrMode_gp = 0;
-    static constexpr int extraMode_gp = 4;
+    static constexpr uint8_t mode_gm = 0xf;
+    static constexpr int op1_gp = 0;
+    static constexpr int op2_gp = 4;
 };
 
 } // namespace mc6809

--- a/src/entry_z8000.h
+++ b/src/entry_z8000.h
@@ -57,7 +57,7 @@ enum AddrMode : uint8_t {
     M_SCNT = 17, // Signed Count: #-32~32
     M_NCNT = 18, // Signed Negative Count: #-32~32
     M_CC   = 19, // Condition Code: F/Z/NZ/C/NC/PL/MI/NE/EQ/OV/NOV/PE/PO/GE/LT/GT/LE/UGE/ULT/UGT/ULE
-    M_INTT = 20, // Interrupt type: VI/NVI
+    M_INTR = 20, // Interrupt type: VI/NVI
     M_CTL  = 21, // Control Register: FCW/REFRESH/NSPSRG/NSPOFF/PSAPSEG/PSAPOFF/FLAGS
     M_FLAG = 22, // Flags: C/Z/S/P/V
     M_RA12 = 23, // 12-bit Relative: (-2048~+2047)*22

--- a/src/insn_cdp1802.h
+++ b/src/insn_cdp1802.h
@@ -36,20 +36,23 @@ public:
         _flags = Entry::_flags(addrMode);
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
+
     void emitInsn() {
         emitByte(_opCode);
     }
 
 private:
-    Config::opcode_t _opCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
 };
 
 } // namespace ins8060

--- a/src/insn_i8051.h
+++ b/src/insn_i8051.h
@@ -31,39 +31,44 @@ public:
     AddrMode dstMode() const { return Entry::_dstMode(_flags); }
     AddrMode srcMode() const { return Entry::_srcMode(_flags); }
     AddrMode extMode() const { return Entry::_extMode(_flags); }
+
+    void setFlags(uint16_t flags) { _flags = flags; }
+
     void setAddrMode(AddrMode dst, AddrMode src, AddrMode ext) {
         _flags = Entry::_flags(dst, src, ext);
     }
 
-    void setFlags(uint16_t flags) { _flags = flags; }
-
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
 
     void emitInsn() {
         emitByte(_opCode, 0);
     }
 
     void emitOperand8(uint8_t val) {
-        uint8_t pos = _insn.length();
-        if (pos == 0) pos = 1;
-        emitByte(val, pos);
+        emitByte(val, operandPos());
     }
 
     void emitOperand16(uint16_t val) {
-        uint8_t pos = _insn.length();
-        if (pos == 0) pos = 1;
-        emitUint16(val, pos);
+        emitUint16(val, operandPos());
     }
 
 private:
-    Config::opcode_t _opCode;
     uint16_t _flags;
+    Config::opcode_t _opCode;
+
+    uint8_t operandPos() const {
+        uint8_t pos = length();
+        if (pos == 0) pos = 1;
+        return pos;
+    }
 };
 
 } // namespace i8051

--- a/src/insn_i8080.h
+++ b/src/insn_i8080.h
@@ -33,17 +33,19 @@ public:
 
     void setFlags(uint8_t flags) { _flags = flags; }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
 
+    Config::opcode_t opCode() const { return _opCode; }
+
 private:
-    Config::opcode_t _opCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
 };
 
 } // namespace i8080

--- a/src/insn_ins8060.h
+++ b/src/insn_ins8060.h
@@ -36,10 +36,12 @@ public:
         _flags = Entry::_flags(addrMode);
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
@@ -48,8 +50,8 @@ public:
     }
 
 private:
-    Config::opcode_t _opCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
 };
 
 } // namespace ins8060

--- a/src/insn_ins8070.h
+++ b/src/insn_ins8070.h
@@ -41,32 +41,36 @@ public:
         _flags = Entry::_flags(addrMode(), dst, src, oprSize());
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
     void emitInsn() {
         emitByte(_opCode, 0);
     }
+
     void emitOperand8(uint8_t val8) {
-        uint8_t pos = _insn.length();
-        if (pos == 0) pos = 1;
-        emitByte(val8, pos);
+        emitByte(val8, operandPos());
     }
+
     void emitOperand16(uint16_t val16) {
-        emitOperand8(static_cast<uint8_t>(val16 >> 0));
-        emitOperand8(static_cast<uint8_t>(val16 >> 8));
+        emitUint16(val16, operandPos());
     }
 
 private:
     Config::opcode_t _opCode;
     uint16_t _flags;
 
-    void emitByte(uint8_t val, uint8_t pos) {
-        _insn.emitByte(val, pos);
+    uint8_t operandPos() const {
+        uint8_t pos = length();
+        if (pos == 0) pos = 1;
+        return pos;
     }
 };
 

--- a/src/insn_mc6800.h
+++ b/src/insn_mc6800.h
@@ -42,9 +42,6 @@ public:
         _flags = Entry::_flags(SZ_NONE, op1, op2, op3);
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
-    bool hasPrefix() const { return _prefix != 0; }
-    Config::opcode_t prefix() const { return _prefix; }
     void setOpCode(Config::opcode_t opCode, Config::opcode_t prefix = 0) {
         _opCode = opCode;
         _prefix = prefix;
@@ -53,6 +50,11 @@ public:
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
+    bool hasPrefix() const { return _prefix != 0; }
+    Config::opcode_t opCode() const { return _opCode; }
+    Config::opcode_t prefix() const { return _prefix; }
+
     void emitInsn() {
         if (hasPrefix())
             emitByte(prefix());
@@ -60,9 +62,9 @@ public:
     }
 
 private:
+    uint16_t _flags;
     Config::opcode_t _opCode;
     Config::opcode_t _prefix;
-    uint16_t _flags;
 };
 
 } // namespace mc6800

--- a/src/insn_mc6809.h
+++ b/src/insn_mc6809.h
@@ -28,39 +28,40 @@ class InsnMc6809 : public InsnBase<Config> {
 public:
     InsnMc6809(Insn &insn) : InsnBase(insn) {}
 
-    AddrMode addrMode() const { return Entry::_addrMode(_flags); }
-    AddrMode extraMode() const { return Entry::_extraMode(_flags); }
+    AddrMode mode1() const { return Entry::_mode1(_flags); }
+    AddrMode mode2() const { return Entry::_mode2(_flags); }
 
     void setFlags(uint8_t flags) {
         _flags = flags;
     }
 
-    void setAddrMode(AddrMode mode, AddrMode extra) {
-        _flags = Entry::_flags(mode, extra);
+    void setAddrMode(AddrMode op1, AddrMode op2) {
+        _flags = Entry::_flags(op1, op2);
     }
 
-    void setOpCode(
-        Config::opcode_t opCode, Config::opcode_t prefixCode = 0) {
+    void setOpCode(Config::opcode_t opCode, Config::opcode_t prefix = 0) {
         _opCode = opCode;
-        _prefixCode = prefixCode;
+        _prefix = prefix;
     }
-    void embed(Config::opcode_t opCode) {
-        _opCode |= opCode;
+
+    void embed(Config::opcode_t data) {
+        _opCode |= data;
     }
-    bool hasPrefix() const { return prefixCode() != 0; }
-    Config::opcode_t prefixCode() const { return _prefixCode; }
+
+    bool hasPrefix() const { return prefix() != 0; }
+    Config::opcode_t prefix() const { return _prefix; }
     Config::opcode_t opCode() const { return _opCode; }
 
     void emitInsn() {
         if (hasPrefix())
-            emitByte(prefixCode());
+            emitByte(prefix());
         emitByte(opCode());
     }
 
 private:
-    Config::opcode_t _opCode;
-    Config::opcode_t _prefixCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
+    Config::opcode_t _prefix;
 };
 
 } // namespace mc6809

--- a/src/insn_mos6502.h
+++ b/src/insn_mos6502.h
@@ -30,7 +30,6 @@ public:
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
 
-    uint8_t flags() const { return _flags; }
     void setFlags(uint8_t flags) {
         _flags = flags;
     }
@@ -39,17 +38,19 @@ public:
         _flags = Entry::_flags(addrMode);
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
+
     void emitInsn() {
         emitByte(_opCode);
     }
 
 private:
-    Config::opcode_t _opCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
 };
 
 } // namespace mos6502

--- a/src/insn_ns32000.h
+++ b/src/insn_ns32000.h
@@ -46,28 +46,6 @@ public:
         _ex2 = Entry::_ex2(flags);
         _hasPost = false;
     }
-    void setOpCode(Config::opcode_t opCode, Config::opcode_t prefix = 0) {
-        _opCode = opCode;
-        _prefix = prefix;
-        _post = 0;
-    }
-    void setHasPost() { _hasPost = true; }
-    void setIndexByte(uint8_t data, OprPos pos) {
-        if (pos == P_GEN1) _indexByte1 = data;
-        if (pos == P_GEN2) _indexByte2 = data;
-    }
-
-    Config::opcode_t opCode() const { return _opCode; }
-    bool hasPrefix() const { return _prefix != 0; }
-    Config::opcode_t prefix() const { return _prefix; }
-    bool hasPost() const { return _hasPost; }
-    uint8_t post() const { return _post; }
-    Error readPost(DisMemory &memory) {
-        return readByte(memory, _post) ? NO_MEMORY : OK;
-    }
-    uint8_t indexByte(OprPos pos) const {
-        return pos == P_GEN1 ? _indexByte1 : _indexByte2;
-    }
 
     void setAddrMode(AddrMode src, AddrMode dst, AddrMode ex1, AddrMode ex2) {
         _src = Entry::_opr(src, P_NONE);
@@ -75,24 +53,56 @@ public:
         _ex1 = Entry::_opr(ex1, P_NONE);
         _ex2 = Entry::_ex2(ex2, P_NONE, SZ_NONE);
     }
+
+    void setOpCode(Config::opcode_t opCode, Config::opcode_t prefix = 0) {
+        _opCode = opCode;
+        _prefix = prefix;
+        _post = 0;
+    }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
     void embedPost(Config::opcode_t data) {
         _post |= data;
     }
+
+    void setIndexByte(uint8_t data, OprPos pos) {
+        if (pos == P_GEN1) _indexByte1 = data;
+        if (pos == P_GEN2) _indexByte2 = data;
+    }
+
+    void readPost(DisMemory &memory) {
+        _post = readByte(memory);
+    }
+
+    void setHasPost() { _hasPost = true; }
+
+    Config::opcode_t opCode() const { return _opCode; }
+    bool hasPrefix() const { return _prefix != 0; }
+    Config::opcode_t prefix() const { return _prefix; }
+    bool hasPost() const { return _hasPost; }
+    uint8_t post() const { return _post; }
+    uint8_t indexByte(OprPos pos) const {
+        return pos == P_GEN1 ? _indexByte1 : _indexByte2;
+    }
+
     void emitInsn() {
         uint8_t pos = 0;
         if (hasPrefix()) emitByte(_prefix, pos++);
         emitByte(_opCode, pos++);
         if (hasPost()) emitByte(_post, pos);
     }
+
     void emitOperand8(uint8_t val8) {
         emitByte(val8, operandPos());
     }
+
     void emitOperand16(uint16_t val16) {
         emitUint16(val16, operandPos());
     }
+
     void emitOperand32(uint32_t val32) {
         emitUint32(val32, operandPos());
     }
@@ -110,7 +120,7 @@ private:
     uint8_t _indexByte2;
 
     uint8_t operandPos() {
-        uint8_t pos = _insn.length();
+        uint8_t pos = length();
         if (pos == 0) {
             if (hasPrefix()) pos++;
             pos++;

--- a/src/insn_tms9900.h
+++ b/src/insn_tms9900.h
@@ -32,27 +32,33 @@ public:
 
     void setFlags(uint8_t flags) { _flags = flags; }
 
-    Config::opcode_t opCode() const { return _opCode; }
     void setOpCode(Config::opcode_t opCode) {
         _opCode = opCode;
     }
+
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
 
     void emitInsn() {
         emitUint16(_opCode, 0);
     }
 
-    void emitOperand(uint16_t val) {
-        uint8_t pos = _insn.length();
-        if (pos == 0) pos = 2;
-        emitUint16(val, pos);
+    void emitOperand16(uint16_t val) {
+        emitUint16(val, operandPos());
     }
 
 private:
-    Config::opcode_t _opCode;
     uint8_t _flags;
+    Config::opcode_t _opCode;
+
+    uint8_t operandPos() const {
+        uint8_t pos = length();
+        if (pos == 0) pos = 2;
+        return pos;
+    }
 };
 
 } // namespace tms9900

--- a/src/insn_z8.h
+++ b/src/insn_z8.h
@@ -32,7 +32,7 @@ public:
     AddrMode srcMode() const { return Entry::_srcMode(_flags); }
     AddrMode extMode() const { return Entry::_extMode(_flags); }
     PostFormat postFormat() const { return Entry::_postFormat(_flags); }
-    uint16_t flags() const { return _flags; }
+
     void setFlags(uint16_t flags) {
         _flags = flags;
     }
@@ -41,29 +41,30 @@ public:
         _flags = Entry::_flags(dstMode, srcMode, extMode, postFormat());
     }
 
+    void setOpCode(Config::opcode_t opCode) {
+        _opCode = opCode;
+    }
+
+    void embed(Config::opcode_t data) {
+        _opCode |= data;
+    }
+
+    void readPost(DisMemory &memory) {
+        readByte(memory);
+    }
+
     Config::opcode_t opCode() const { return _opCode; }
-    uint8_t post() const { return _insn.bytes()[1]; }
+
+    uint8_t post() const { return bytes()[1]; }
 
     static bool operandInOpCode(Config::opcode_t opCode) {
         const Config::opcode_t low4 = opCode & 0xF;
         return low4 >= 0x8 && low4 < 0xF;
     }
+
     bool singleByteOpCode() const {
         const Config::opcode_t low4 = _opCode & 0xF;
         return low4 == 0x0E || low4 == 0xF;
-    }
-
-    void setOpCode(Config::opcode_t opCode) {
-        _opCode = opCode;
-    }
-
-    Error readPost(DisMemory &memory) {
-        uint8_t post;
-        return readByte(memory, post) ? NO_MEMORY : OK;
-    }
-
-    void embed(Config::opcode_t data) {
-        _opCode |= data;
     }
 
     void emitInsn() {

--- a/src/insn_z80.h
+++ b/src/insn_z80.h
@@ -27,50 +27,53 @@ namespace z80 {
 class InsnZ80 : public InsnBase<Config> {
 public:
     InsnZ80(Insn &insn) : InsnBase(insn) {}
-    InsnZ80(InsnZ80 &other) : InsnBase(other._insn) {}
 
     AddrMode addrMode() const { return Entry::_addrMode(_flags); }
     InsnFormat insnFormat() const { return Entry::_insnFormat(_flags); }
     OprFormat dstFormat() const { return Entry::_dstFormat(_flags); }
     OprFormat srcFormat() const { return Entry::_srcFormat(_flags); }
-    void setOprFormats(OprFormat dst, OprFormat src) {
-        _flags = Entry::_flags(insnFormat(), addrMode(), dst, src);
-    }
 
     void setFlags(uint16_t flags) {
         _flags = flags;
     }
+
     void setFlags(const InsnZ80 &other) {
         _flags = other._flags;
     }
 
-    uint16_t insnCode() const { return _insnCode; }
-    void setInsnCode(uint16_t insnCode) {
-        _insnCode = insnCode;
+    void setOprFormats(OprFormat dst, OprFormat src) {
+        _flags = Entry::_flags(insnFormat(), addrMode(), dst, src);
     }
+
+    void setOpCode(Config::opcode_t opCode, Config::opcode_t prefix = 0) {
+        _opCode = opCode;
+        _prefix = prefix;
+    }
+
     void embed(Config::opcode_t data) {
-        _insnCode |= data;
+        _opCode |= data;
     }
-    void setInsnCode(Config::opcode_t prefixCode, Config::opcode_t opCode) {
-        _insnCode = (static_cast<uint16_t>(prefixCode) << 8) | opCode;
+
+    bool hasPrefix() const { return prefix() != 0; }
+
+    Config::opcode_t prefix() const {
+        return _prefix;
     }
-    bool hasPrefix() const { return prefixCode() != 0; }
-    Config::opcode_t prefixCode() const {
-        return static_cast<Config::opcode_t>(_insnCode >> 8);
-    }
+
     Config::opcode_t opCode() const {
-        return static_cast<Config::opcode_t>(_insnCode);
+        return _opCode;
     }
 
     void emitInsn() {
         if (hasPrefix())
-            emitByte(prefixCode());
+            emitByte(prefix());
         emitByte(opCode());
     }
 
 private:
-    uint16_t _insnCode;
     uint16_t _flags;
+    Config::opcode_t _opCode;
+    Config::opcode_t _prefix;
 };
 
 } // namespace z80

--- a/src/insn_z8000.h
+++ b/src/insn_z8000.h
@@ -47,12 +47,6 @@ public:
         _size = Entry::_size(flags);
     }
 
-    Config::opcode_t opCode() const { return _opCode; }
-    void setOpCode(Config::opcode_t opCode) {
-        _opCode = opCode;
-        _post = 0;
-    }
-
     void setAddrMode(
             AddrMode dst, AddrMode src, AddrMode ex1, AddrMode ex2) {
         _dst = Entry::_opr(dst, MF_NO);
@@ -60,17 +54,26 @@ public:
         _ext = Entry::_ext(ex1, ex2, P_NO);
     }
 
-    uint16_t post() const { return _post; }
-    Error readPost(DisMemory &memory) {
-        return readUint16(memory, _post) ? NO_MEMORY : OK;
+    void setOpCode(Config::opcode_t opCode) {
+        _opCode = opCode;
+        _post = 0;
+    }
+
+    void readPost(DisMemory &memory) {
+        _post = readUint16(memory);
     }
 
     void embed(Config::opcode_t data) {
         _opCode |= data;
     }
+
     void embedPost(Config::opcode_t data) {
         _post |= data;
     }
+
+    Config::opcode_t opCode() const { return _opCode; }
+    uint16_t post() const { return _post; }
+
     void emitInsn() {
         emitUint16(_opCode, 0);
         const PostMode mode = postMode();
@@ -89,11 +92,11 @@ public:
 
 private:
     Config::opcode_t _opCode;
+    Config::opcode_t _post;
     uint8_t _dst;
     uint8_t _src;
     uint8_t _ext;
     uint8_t _size;
-    Config::opcode_t _post;
 
     uint8_t operandPos() {
         uint8_t pos = length();

--- a/src/reg_i8051.h
+++ b/src/reg_i8051.h
@@ -22,43 +22,34 @@
 namespace libasm {
 namespace i8051 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_R0 = '0',
-    REG_R1 = '1',
-    REG_R2 = '2',
-    REG_R3 = '3',
-    REG_R4 = '4',
-    REG_R5 = '5',
-    REG_R6 = '6',
-    REG_R7 = '7',
-    REG_A  = 'A',
-    REG_AB = 'a',
-    REG_C  = 'C',
-    REG_DPTR = 'd',
-    REG_PC = 'p',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // R registers.
+    REG_R0   = 0,
+    REG_R1   = 1,
+    REG_R2   = 2,
+    REG_R3   = 3,
+    REG_R4   = 4,
+    REG_R5   = 5,
+    REG_R6   = 6,
+    REG_R7   = 7,
+    // Other registers.
+    REG_A    = 0 + 8,
+    REG_AB   = 1 + 8,
+    REG_C    = 2 + 8,
+    REG_PC   = 3 + 8,
+    REG_DPTR = 4 + 8,
 };
 
 class RegI8051 : public RegBase {
 public:
-    RegName parseRegister(const char *line) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, const RegName name) const;
 
-    bool isRReg(RegName regName) const;
-    int8_t encodeRReg(RegName regName) const;
-    RegName decodeRReg(uint8_t regNum) const;
-
-    bool compareRegName(const char *line, RegName regName) const;
-    uint8_t regNameLen(RegName regName) const;
-
-    char *outRegName(char *out, const RegName regName) const;
-
-private:
-    RegName parseRegName(
-        const char *line, const RegName *tabel, const RegName *end) const;
-    char regName1stChar(RegName regName) const;
-    char regName2ndChar(RegName regName) const;
-    char regName3rdChar(RegName regName) const;
-    char regName4thChar(RegName regName) const;
+    static bool isRReg(RegName name);
+    static uint8_t encodeRReg(RegName name);
+    static RegName decodeRReg(uint8_t num);
 };
 
 } // namespace i8051

--- a/src/reg_i8080.h
+++ b/src/reg_i8080.h
@@ -22,49 +22,41 @@
 namespace libasm {
 namespace i8080 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_B = 'B',
-    REG_C = 'C',
-    REG_D = 'D',
-    REG_E = 'E',
-    REG_H = 'H',
-    REG_L = 'L',
-    REG_M = 'M',
-    REG_A = 'A',
-    REG_SP = 'S',
-    REG_PSW = 'P',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // Data registers.
+    REG_B   = 0,
+    REG_C   = 1,
+    REG_D   = 2,
+    REG_E   = 3,
+    REG_H   = 4,
+    REG_L   = 5,
+    REG_M   = 6,
+    REG_A   = 7,
+    // Other registers
+    REG_SP  = 0 + 8,
+    REG_PSW = 1 + 8,
 };
 
 class RegI8080 : public RegBase {
 public:
-    RegName parseRegister(const char *line) const;
-    RegName parsePointerReg(const char *line) const;
-    RegName parseStackReg(const char *line) const;
-    RegName parseIndexReg(const char *line) const;
-    RegName parseDataReg(const char *line) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName regName);
+    char *outRegName(char *out, const RegName name) const;
 
-    static int8_t encodePointerReg(RegName regName);
-    static int8_t encodeStackReg(RegName regName);
-    static int8_t encodeIndexReg(RegName regName);
-    static int8_t encodeDataReg(RegName regName);
+    static bool isPointerReg(RegName name);
+    static uint8_t encodePointerReg(RegName name);
+    static bool isStackReg(RegName name);
+    static uint8_t encodeStackReg(RegName name);
+    static bool isIndexReg(RegName name);
+    static uint8_t encodeIndexReg(RegName name);
+    static bool isDataReg(RegName name);
+    static uint8_t encodeDataReg(RegName name);
 
-    static RegName decodePointerReg(uint8_t regNum);
-    static RegName decodeStackReg(uint8_t regNum);
-    static RegName decodeIndexReg(uint8_t regNum);
-    static RegName decodeDataReg(uint8_t regNum);
-
-    bool compareRegName(const char *line, RegName regName) const;
-    uint8_t regNameLen(RegName regName) const;
-
-    char *outRegName(char *out, const RegName regName) const;
-
-private:
-    RegName parseRegName(
-        const char *line, const RegName *tabel, const RegName *end) const;
-    char regName1stChar(RegName regName) const;
-    char regName2ndChar(RegName regName) const;
-    char regName3rdChar(RegName regName) const;
+    static RegName decodePointerReg(uint8_t num);
+    static RegName decodeStackReg(uint8_t num);
+    static RegName decodeIndexReg(uint8_t num);
+    static RegName decodeDataReg(uint8_t num);
 };
 
 } // namespace i8080

--- a/src/reg_i8086.h
+++ b/src/reg_i8086.h
@@ -23,11 +23,18 @@
 namespace libasm {
 namespace i8086 {
 
-enum RegName : uint8_t {
-    REG_UNDEF = 0,
-    REG_BYTE  = 1,
-    REG_WORD  = 2,
-    REG_PTR   = 3,
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // General word registers.
+    REG_AX = 0 + 0,
+    REG_CX = 1 + 0,
+    REG_DX = 2 + 0,
+    REG_BX = 3 + 0,
+    REG_SP = 4 + 0,
+    REG_BP = 5 + 0,
+    REG_SI = 6 + 0,
+    REG_DI = 7 + 0,
+    // General byte registers.
     REG_AL = 0 + 8,
     REG_CL = 1 + 8,
     REG_DL = 2 + 8,
@@ -36,32 +43,30 @@ enum RegName : uint8_t {
     REG_CH = 5 + 8,
     REG_DH = 6 + 8,
     REG_BH = 7 + 8,
-    REG_AX = 0 + 16,
-    REG_CX = 1 + 16,
-    REG_DX = 2 + 16,
-    REG_BX = 3 + 16,
-    REG_SP = 4 + 16,
-    REG_BP = 5 + 16,
-    REG_SI = 6 + 16,
-    REG_DI = 7 + 16,
-    REG_ES = 0 + 24,
-    REG_CS = 1 + 24,
-    REG_SS = 2 + 24,
-    REG_DS = 3 + 24,
+    // Segment registers.
+    REG_ES = 0 + 16,
+    REG_CS = 1 + 16,
+    REG_SS = 2 + 16,
+    REG_DS = 3 + 16,
+    // Other registers.
+    REG_BYTE = 0 + 20,
+    REG_WORD = 1 + 20,
+    REG_PTR  = 2 + 20,
 };
 
 class RegI8086 : public RegBase {
 public:
-    RegName parseRegName(const char *line) const;
-    uint8_t regNameLen(RegName name) const;
-    RegName decodeByteReg(uint8_t num) const;
-    RegName decodeWordReg(uint8_t num) const;
-    RegName decodeSegReg(uint8_t num) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
     char *outRegName(char *out, const RegName name) const;
-    uint8_t encodeRegNum(RegName name) const;
-    bool isGeneralReg(RegName name) const;
-    bool isSegmentReg(RegName name) const;
-    OprSize regSize(RegName name) const;
+
+    static RegName decodeByteReg(uint8_t num);
+    static RegName decodeWordReg(uint8_t num);
+    static RegName decodeSegReg(uint8_t num);
+    static uint8_t encodeRegNum(RegName name);
+    static bool isGeneralReg(RegName name);
+    static bool isSegmentReg(RegName name);
+    static OprSize generalRegSize(RegName name);
 };
 
 } // namespace i8086

--- a/src/reg_ins8060.h
+++ b/src/reg_ins8060.h
@@ -22,35 +22,27 @@
 namespace libasm {
 namespace ins8060 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_P0 = '0',
-    REG_P1 = '1',
-    REG_P2 = '2',
-    REG_P3 = '3',
-    REG_E  = 'E',
-    REG_PC = 'P',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // Pointer registers.
+    REG_PC = 0,
+    REG_P1 = 1,
+    REG_P2 = 2,
+    REG_P3 = 3,
+    // Other registers.
+    REG_P0 = 0 + 4, // Alias of PC
+    REG_E  = 1 + 4,
 };
 
 class RegIns8060 : public RegBase {
 public:
-    RegName parseRegister(const char *line) const;
-    RegName parsePointerReg(const char *line) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, const RegName name) const;
 
-    static int8_t encodePointerReg(RegName regName);
-
-    static RegName decodePointerReg(uint8_t regNum);
-
-    bool compareRegName(const char *line, RegName regName) const;
-    uint8_t regNameLen(RegName regName) const;
-
-    char *outRegName(char *out, const RegName regName) const;
-
-private:
-    RegName parseRegName(
-        const char *line, const RegName *tabel, const RegName *end) const;
-    char regName1stChar(RegName regName) const;
-    char regName2ndChar(RegName regName) const;
+    static bool isPointerReg(RegName name);
+    static uint8_t encodePointerReg(RegName name);
+    static RegName decodePointerReg(uint8_t num);
 };
 
 } // namespace ins8060

--- a/src/reg_ins8070.cpp
+++ b/src/reg_ins8070.cpp
@@ -22,86 +22,54 @@
 namespace libasm {
 namespace ins8070 {
 
-static constexpr RegName ALL_REGS[] PROGMEM = {
-    REG_PC, REG_SP, REG_P2, REG_P3,
-    REG_A,  REG_E,  REG_EA, REG_T,  REG_S
+static const char TEXT_REG_A[]  PROGMEM = "A";
+static const char TEXT_REG_E[]  PROGMEM = "E";
+static const char TEXT_REG_EA[] PROGMEM = "EA";
+static const char TEXT_REG_T[]  PROGMEM = "T";
+static const char TEXT_REG_S[]  PROGMEM = "S";
+static const char TEXT_REG_PC[] PROGMEM = "PC";
+static const char TEXT_REG_SP[] PROGMEM = "SP";
+static const char TEXT_REG_P2[] PROGMEM = "P2";
+static const char TEXT_REG_P3[] PROGMEM = "P3";
+static constexpr RegBase::NameEntry REG_TABLE[] PROGMEM = {
+    NAME_ENTRY(REG_A)
+    NAME_ENTRY(REG_E)
+    NAME_ENTRY(REG_EA)
+    NAME_ENTRY(REG_T)
+    NAME_ENTRY(REG_S)
+    NAME_ENTRY(REG_PC)
+    NAME_ENTRY(REG_SP)
+    NAME_ENTRY(REG_P2)
+    NAME_ENTRY(REG_P3)
 };
 
-static constexpr RegName POINTER_REGS[] PROGMEM = {
-    REG_PC, REG_SP, REG_P2, REG_P3
-};
-
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
+RegName RegIns8070::parseRegName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(REG_TABLE));
+    return entry ? RegName(entry->name()) : REG_UNDEF;
 }
 
-static bool regCharCaseEqual(char c, char regChar) {
-    return toupper(c) == toupper(regChar);
+uint8_t RegIns8070::regNameLen(RegName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(REG_TABLE));
 }
 
-char RegIns8070::regName1stChar(const RegName regName) const {
-    char r = char(regName);
-    if (isdigit(r)) r = 'p';
-    return _uppercase ? toupper(r) : tolower(r);
-}
-
-char RegIns8070::regName2ndChar(const RegName regName) const {
-    char r = 0;
-    if (regName == REG_EA) r = 'a';
-    if (regName == REG_PC) r = 'c';
-    if (regName == REG_SP) r = 'p';
-    if (isdigit(char(regName))) r = char(regName);
-    return _uppercase ? toupper(r) : tolower(r);
-}
-
-bool RegIns8070::compareRegName(const char *line, RegName regName) const {
-    if (!regCharCaseEqual(*line++, regName1stChar(regName))) return false;
-    const char r2 = regName2ndChar(regName);
-    if (r2 && !regCharCaseEqual(*line++, r2)) return false;
-    return !isidchar(*line);
-}
-
-uint8_t RegIns8070::regNameLen(RegName regName) const {
-    if (regName == REG_UNDEF) return 0;
-    return regName2ndChar(regName) ? 2 : 1;
-}
-
-char *RegIns8070::outRegName(char *out, const RegName regName) const {
-    *out++ = regName1stChar(regName);
-    const char r2 = regName2ndChar(regName);
-    if (r2) *out++ = r2;
-    *out = 0;
+char *RegIns8070::outRegName(char *out, const RegName name) const {
+    const NameEntry *entry = searchName(uint8_t(name), ARRAY_RANGE(REG_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
     return out;
 }
 
-RegName RegIns8070::parseRegName(
-    const char *line, const RegName *table, const RegName *end) const {
-    for (const RegName *p = table; p < end; p++) {
-        const RegName regName = RegName(pgm_read_byte(p));
-        if (compareRegName(line, regName)) return regName;
-    }
-    return REG_UNDEF;
+bool RegIns8070::isPointerReg(RegName name) {
+    const int8_t num = int8_t(name);
+    return num >= 0 && num < 4;
 }
 
-RegName RegIns8070::parseRegister(const char *line) const {
-    return parseRegName(line, ARRAY_RANGE(ALL_REGS));
+uint8_t RegIns8070::encodePointerReg(RegName name) {
+    return uint8_t(name);
 }
 
-RegName RegIns8070::parsePointerReg(const char *line) const {
-    return parseRegName(line, ARRAY_RANGE(POINTER_REGS));
-}
-
-int8_t RegIns8070::encodePointerReg(RegName regName) {
-    if (regName == REG_PC) return 0;
-    if (regName == REG_SP) return 1;
-    return char(regName) - '0';
-}
-
-RegName RegIns8070::decodePointerReg(uint8_t regNum) {
-    regNum &= 3;
-    if (regNum == 0) return REG_PC;
-    if (regNum == 1) return REG_SP;
-    return RegName(regNum + '0');
+RegName RegIns8070::decodePointerReg(uint8_t num) {
+    return RegName(num & 3);
 }
 
 } // namespace ins8070

--- a/src/reg_ins8070.h
+++ b/src/reg_ins8070.h
@@ -22,38 +22,30 @@
 namespace libasm {
 namespace ins8070 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_PC = 'P',
-    REG_SP = 'S',
-    REG_P2 = '2',
-    REG_P3 = '3',
-    REG_A  = 'A',
-    REG_E  = 'E',
-    REG_EA = 'e',
-    REG_T  = 'T',
-    REG_S  = 's',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // Pointer registers.
+    REG_PC = 0,
+    REG_SP = 1,
+    REG_P2 = 2,
+    REG_P3 = 3,
+    // Other registers.
+    REG_A  = 0 + 4,
+    REG_E  = 1 + 4,
+    REG_EA = 2 + 4,
+    REG_T  = 3 + 4,
+    REG_S  = 5 + 4,
 };
 
 class RegIns8070 : public RegBase {
 public:
-    RegName parseRegister(const char *line) const;
-    RegName parsePointerReg(const char *line) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, const RegName name) const;
 
-    static int8_t encodePointerReg(RegName regName);
-
-    static RegName decodePointerReg(uint8_t regNum);
-
-    bool compareRegName(const char *line, RegName regName) const;
-    uint8_t regNameLen(RegName regName) const;
-
-    char *outRegName(char *out, const RegName regName) const;
-
-private:
-    RegName parseRegName(
-        const char *line, const RegName *tabel, const RegName *end) const;
-    char regName1stChar(RegName regName) const;
-    char regName2ndChar(RegName regName) const;
+    static bool isPointerReg(RegName name);
+    static uint8_t encodePointerReg(RegName name);
+    static RegName decodePointerReg(uint8_t num);
 };
 
 } // namespace ins8070

--- a/src/reg_mc6800.cpp
+++ b/src/reg_mc6800.cpp
@@ -23,39 +23,22 @@
 namespace libasm {
 namespace mc6800 {
 
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
+RegName RegMc6800::parseRegName(const char *line) {
+    const char r = *line++;
+    if (isidchar(*line)) return REG_UNDEF;
+    switch (toupper(r)) {
+    case 'X': return REG_X;
+    case 'Y': return REG_Y;
+    default:  return REG_UNDEF;
+    }
 }
 
-static bool regCharCaseEqual(char c, char regChar) {
-    return toupper(c) == toupper(regChar);
-}
-
-char RegMc6800::regName1stChar(const RegName name) const {
-    const char r = char(name);
-    return _uppercase ? toupper(r) : tolower(r);
-}
-
-bool RegMc6800::compareRegName(const char *line, RegName name) const {
-    if (!regCharCaseEqual(*line++, regName1stChar(name))) return false;
-    return !isidchar(*line);
-}
-
-uint8_t RegMc6800::regNameLen(RegName name) const {
+uint8_t RegMc6800::regNameLen(RegName name) {
     return name == REG_UNDEF ? 0 : 1;
 }
 
 char *RegMc6800::outRegName(char *out, const RegName name) const {
-    *out++ = regName1stChar(name);
-    *out = 0;
-    return out;
-}
-
-RegName RegMc6800::parseRegName(const char *line) const {
-    if (compareRegName(line, REG_X)) return REG_X;
-    if (TableMc6800.cpuType() == MC68HC11 && compareRegName(line, REG_Y))
-        return REG_Y;
-    return REG_UNDEF;
+    return outChar(out, char(name));
 }
 
 } // namespace mc6800

--- a/src/reg_mc6800.h
+++ b/src/reg_mc6800.h
@@ -31,12 +31,9 @@ enum RegName : char {
 
 class RegMc6800 : public RegBase {
 public:
-    RegName parseRegName(const char *line) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
     char *outRegName(char *out, const RegName name) const;
-    uint8_t regNameLen(RegName name) const;
-private:
-    bool compareRegName(const char *line, RegName name) const;
-    char regName1stChar(const RegName name) const;
 };
 
 } // namespace mc6800

--- a/src/reg_mc68000.h
+++ b/src/reg_mc68000.h
@@ -23,50 +23,57 @@
 namespace libasm {
 namespace mc68000 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_D0 = '0',
-    REG_D1 = '1',
-    REG_D2 = '2',
-    REG_D3 = '3',
-    REG_D4 = '4',
-    REG_D5 = '5',
-    REG_D6 = '6',
-    REG_D7 = '7',
-    REG_A0 = 'a',
-    REG_A1 = 'b',
-    REG_A2 = 'c',
-    REG_A3 = 'd',
-    REG_A4 = 'e',
-    REG_A5 = 'f',
-    REG_A6 = 'g',
-    REG_A7 = 'h',
-    REG_CCR = 'C',
-    REG_PC = 'P',
-    REG_SR = 'S',
-    REG_USP = 'U',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // Data registers.
+    REG_D0 = 0 + 0,
+    REG_D1 = 1 + 0,
+    REG_D2 = 2 + 0,
+    REG_D3 = 3 + 0,
+    REG_D4 = 4 + 0,
+    REG_D5 = 5 + 0,
+    REG_D6 = 6 + 0,
+    REG_D7 = 7 + 0,
+    // Address registers.
+    REG_A0 = 0 + 8,
+    REG_A1 = 1 + 8,
+    REG_A2 = 2 + 8,
+    REG_A3 = 3 + 8,
+    REG_A4 = 4 + 8,
+    REG_A5 = 5 + 8,
+    REG_A6 = 6 + 8,
+    REG_A7 = 7 + 8,
+    // Other registers.
+    REG_CCR = 0 + 16,
+    REG_PC  = 1 + 16,
+    REG_SR  = 2 + 16,
+    REG_USP = 3 + 16,
 };
 
 class RegMc68000 : public RegBase {
 public:
-    static uint8_t regNameLen(RegName);
     static RegName parseRegName(const char *line);
-    char *outRegName(char *out, RegName regName) const;
-    char *outOprSize(char *out, OprSize size) const;
-    static bool isDreg(RegName reg);
-    static bool isAreg(RegName reg);
-    static bool isADreg(RegName reg);
-    static Config::opcode_t encodeRegNo(RegName reg);
-    static uint8_t encodeRegPos(RegName reg);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, RegName name);
+    static bool isDataReg(RegName name);
+    static bool isAddrReg(RegName name);
+    static bool isGeneralReg(RegName name);
+    static Config::opcode_t encodeGeneralRegNo(RegName name);
+    static uint8_t encodeGeneralRegPos(RegName name);
+    static RegName decodeGeneralReg(uint8_t regno);
     static RegName decodeDataReg(uint8_t regno);
     static RegName decodeAddrReg(uint8_t regno);
+
+    static OprSize parseSize(const char *line);
+    static uint8_t sizeNameLen(OprSize size);
+    char sizeSuffix(OprSize size) const;
 };
 
 struct EaMc68000 {
     EaMc68000(OprSize size, uint8_t mode, uint8_t regno);
 
     static Config::opcode_t encodeMode(AddrMode mode);
-    static Config::opcode_t encodeRegNo(AddrMode mode, RegName regName);
+    static Config::opcode_t encodeRegNo(AddrMode mode, RegName reg);
 
     OprSize size;
     AddrMode mode;

--- a/src/reg_mc6809.cpp
+++ b/src/reg_mc6809.cpp
@@ -23,49 +23,6 @@
 namespace libasm {
 namespace mc6809 {
 
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
-}
-
-struct RegEntry {
-    RegName _name;
-    const /*PROGMEM*/ char *_text;
-
-    static const RegEntry *searchName(
-            RegName name, const RegEntry *begin, const RegEntry *end) {
-        for (const RegEntry *entry = begin; entry < end; entry++) {
-            if (entry->name() == name) return entry;
-        }
-        return nullptr;
-    }
-    static const RegEntry *searchText(
-            const char *str, const RegEntry *begin, const RegEntry *end) {
-        for (const RegEntry *entry = begin; entry < end; entry++) {
-            const char *text = entry->text();
-            const uint8_t len = strlen_P(text);
-            if (strncasecmp_P(str, text, len) == 0 && !isidchar(str[len]))
-                return entry;
-        }
-        return nullptr;
-    }
-    static uint8_t nameLen(RegName name) {
-        if (name == REG_UNDEF)
-            return 0;
-        if (name == REG_PCR)
-            return 3;
-        if (name == REG_PC || name == REG_CC || name == REG_DP)
-            return 2;
-        return 1;
-    }
-    
-    inline RegName name() const {
-        return RegName(pgm_read_byte(&this->_name));
-    }
-    inline const /*PROGMEM*/ char *text() const {
-        return reinterpret_cast<const char *>(pgm_read_ptr(&this->_text));
-    }
-};
-
 static const char TEXT_REG_A[]   PROGMEM = "A";
 static const char TEXT_REG_B[]   PROGMEM = "B";
 static const char TEXT_REG_D[]   PROGMEM = "D";
@@ -83,150 +40,123 @@ static const char TEXT_REG_F[]   PROGMEM = "F";
 static const char TEXT_REG_V[]   PROGMEM = "V";
 static const char TEXT_REG_Z[]   PROGMEM = "Z";
 static const char TEXT_REG_0[]   PROGMEM = "0";
-static constexpr RegEntry REG_TABLE[] PROGMEM = {
-    { REG_A,   TEXT_REG_A },
-    { REG_B,   TEXT_REG_B },
-    { REG_D,   TEXT_REG_D },
-    { REG_X,   TEXT_REG_X },
-    { REG_Y,   TEXT_REG_Y },
-    { REG_U,   TEXT_REG_U },
-    { REG_S,   TEXT_REG_S },
-    { REG_PC,  TEXT_REG_PC },
-    { REG_CC,  TEXT_REG_CC },
-    { REG_DP,  TEXT_REG_DP },
-    { REG_PCR, TEXT_REG_PCR },
-    { REG_W,   TEXT_REG_W },
-    { REG_E,   TEXT_REG_E },
-    { REG_F,   TEXT_REG_F },
-    { REG_V,   TEXT_REG_V },
-    { REG_Z,   TEXT_REG_Z },
-    { REG_0,   TEXT_REG_0 },
+static constexpr RegBase::NameEntry REG_TABLE[] PROGMEM = {
+    NAME_ENTRY(REG_A)
+    NAME_ENTRY(REG_B)
+    NAME_ENTRY(REG_D)
+    NAME_ENTRY(REG_X)
+    NAME_ENTRY(REG_Y)
+    NAME_ENTRY(REG_U)
+    NAME_ENTRY(REG_S)
+    NAME_ENTRY(REG_PC)
+    NAME_ENTRY(REG_CC)
+    NAME_ENTRY(REG_DP)
+    NAME_ENTRY(REG_PCR)
+    NAME_ENTRY(REG_W)
+    NAME_ENTRY(REG_E)
+    NAME_ENTRY(REG_F)
+    NAME_ENTRY(REG_V)
+    NAME_ENTRY(REG_Z)
+    NAME_ENTRY(REG_0)
 };
 
-RegName RegMc6809::parseRegName(const char *line) const {
-    const RegEntry *entry = RegEntry::searchText(line, ARRAY_RANGE(REG_TABLE));
-    return entry ? entry->name() : REG_UNDEF;
+RegName RegMc6809::parseRegName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(REG_TABLE));
+    return entry ? RegName(entry->name()) : REG_UNDEF;
 }
 
-uint8_t RegMc6809::regNameLen(RegName name) const {
-    return RegEntry::nameLen(name);
+uint8_t RegMc6809::regNameLen(RegName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(REG_TABLE));
 }
 
-RegSize RegMc6809::regSize(RegName name) const {
-    const int8_t num = int8_t(name) - 8;
+RegSize RegMc6809::regSize(RegName name) {
+    const int8_t num = int8_t(name);
     if (num >= 0 && num < 8) return SZ_WORD;
     if (num >= 8 && num < 12) return SZ_BYTE;
-    if (num >= 14) return SZ_BYTE;
+    if (num >= 14 && num < 16) return SZ_BYTE;
     return SZ_NONE;
 }
 
 char *RegMc6809::outRegName(char *out, const RegName name) const {
-    const RegEntry *entry = RegEntry::searchName(name, ARRAY_RANGE(REG_TABLE));
-    if (entry) {
-        const char *text = entry->text();
-        char c;
-        while ((c = pgm_read_byte(text++)) != 0)
-            *out++ = _uppercase ? c : tolower(c);
-        *out = 0;
-    }
+    const NameEntry *entry = searchName(name, ARRAY_RANGE(REG_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
     return out;
 }
 
-RegName RegMc6809::decodeDataReg(uint8_t num) const {
-    if (num == 13) num = 12;
+RegName RegMc6809::decodeDataReg(uint8_t num) {
+    num &= 0xF;
+    const RegName name = RegName(num);
     if (TableMc6809.cpuType() == MC6809) {
-        if (num == 6 || num == 7 || num >= 12)
+        if (name == REG_W || name == REG_V || num >= 12)
             return REG_UNDEF;
     }
-    return RegName(num + 8);
+    return (name == REG_0) ? REG_Z : name;
 }
 
-int8_t RegMc6809::encodeDataReg(RegName name) const {
-    int8_t num = int8_t(name) - 8;
-    if (num < 0) return -1;
-    if (num == 13) num = 12;
-    if (TableMc6809.cpuType() == MC6809) {
-        if (num == 6 || num == 7 || num >= 12)
-            return -1;
-    }
-    return num;
-}
-
-RegName RegMc6809::decodeBaseReg(uint8_t num) const {
-    if (num == 4 && TableMc6809.cpuType() == HD6309)
-        return REG_W;
-    switch (num) {
-    case 0:  return REG_X;
-    case 1:  return REG_Y;
-    case 2:  return REG_U;
-    case 3:  return REG_S;
-    default: return REG_UNDEF;
-    }
-}
-
-int8_t RegMc6809::encodeBaseReg(RegName name) const {
-    if (TableMc6809.cpuType() == HD6309 && name == REG_W)
-        return 4;
+bool RegMc6809::isDataReg(RegName name) {
+    if (name == REG_UNDEF) return false;
     switch (name) {
-    case REG_X: return 0;
-    case REG_Y: return 1;
-    case REG_U: return 2;
-    case REG_S: return 3;
-    default:    return -1;
+    case REG_W: case REG_V:
+    case REG_E: case REG_F: case REG_Z: case REG_0:
+        return TableMc6809.cpuType() == HD6309;
+    case REG_PCR:
+        return false;
+    default:
+        return true;
     }
 }
 
-bool RegMc6809::isBaseReg(RegName name) const {
-    switch (name) {
-    case REG_X:
-    case REG_Y:
-    case REG_U:
-    case REG_S:
-    case REG_W: return true;
-    default:    return false;
-    }
+uint8_t RegMc6809::encodeDataReg(RegName name) {
+    if (name == REG_0) name = REG_Z;
+    return uint8_t(name);
 }
 
-int8_t RegMc6809::encodeIndexReg(RegName name) const {
-    if (TableMc6809.cpuType() == HD6309) {
-        switch (name) {
-        case REG_W: return 0xE;
-        case REG_E: return 0x7;
-        case REG_F: return 0xA;
-        default: break;
-        }
-    }
-    switch (name) {
-    case REG_D: return 0xB;
-    case REG_A: return 0x6;
-    case REG_B: return 0x5;
-    default:    return -1;
-    }
+RegName RegMc6809::decodeBaseReg(uint8_t num) {
+    return RegName((num & 3) + 1);
 }
 
-bool RegMc6809::isIndexReg(RegName name) const {
+bool RegMc6809::isBaseReg(RegName name) {
     switch (name) {
-    case REG_D:
-    case REG_A:
-    case REG_B:
+    case REG_X: case REG_Y: case REG_U: case REG_S:
     case REG_W:
-    case REG_E:
-    case REG_F: return true;
-    default:    return false;
+        return true;
+    default:
+        return false;
     }
 }
 
-bool RegMc6809::isIndexedBase(RegName name) const {
-    return isBaseReg(name)
-        || name == REG_PCR
-        || name == REG_PC;
+bool RegMc6809::isIndexedBase(RegName name) {
+    switch (name) {
+    case REG_X: case REG_Y: case REG_U: case REG_S:
+    case REG_PC: case REG_PCR:
+    case REG_W:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool RegMc6809::isIndexReg(RegName name) {
+    switch (name) {
+    case REG_D: case REG_A: case REG_B:
+    case REG_W: case REG_E: case REG_F:
+        return true;
+    default:
+        return false;
+    }
+}
+
+uint8_t RegMc6809::encodeBaseReg(RegName name) {
+    // REG_W is handled separately in TableMc6809::searchPostSpec().
+    return uint8_t(name) - 1;
 }
 
 static constexpr RegName STACK_REGS[8] PROGMEM = {
     REG_CC, REG_A, REG_B, REG_DP, REG_X, REG_Y, REG_U, REG_PC
 };
 
-uint8_t RegMc6809::encodeStackReg(RegName name, bool onUserStack) const {
+uint8_t RegMc6809::encodeStackReg(RegName name, bool onUserStack) {
     if (onUserStack) {
         if (name == REG_U) return 0;
         if (name == REG_S) name = REG_U;
@@ -238,12 +168,12 @@ uint8_t RegMc6809::encodeStackReg(RegName name, bool onUserStack) const {
     return 0;
 }
 
-RegName RegMc6809::decodeStackReg(uint8_t bitPos, bool onUserStack) const {
+RegName RegMc6809::decodeStackReg(uint8_t bitPos, bool onUserStack) {
     const RegName name = RegName(pgm_read_byte(&STACK_REGS[bitPos]));
     return (onUserStack && name == REG_U) ? REG_S : name;
 }
 
-RegName RegMc6809::decodeBitOpReg(uint8_t num) const {
+RegName RegMc6809::decodeBitOpReg(uint8_t num) {
     switch (num) {
     case 0: return REG_CC;
     case 1: return REG_A;
@@ -252,41 +182,39 @@ RegName RegMc6809::decodeBitOpReg(uint8_t num) const {
     }
 }
 
-bool RegMc6809::isBitOpReg(RegName name) const {
-    return name == REG_CC || name == REG_A || name == REG_B;
+bool RegMc6809::isBitOpReg(RegName name) {
+    const uint8_t num = uint8_t(name);
+    return num >= 8 && num < 11;
 }
 
-int8_t RegMc6809::encodeBitOpReg(RegName name) const {
-    switch (name) {
-    case REG_CC: return 0;
-    case REG_A:  return 1;
-    case REG_B:  return 2;
-    default:     return -1;
-    }
+uint8_t RegMc6809::encodeBitOpReg(RegName name) {
+    if (name == REG_CC) return 0;
+    return uint8_t(name) - uint8_t(REG_A) + 1;
 }
 
 
-RegName RegMc6809::decodeTfmBaseReg(uint8_t num) const {
-    return num < 5 ? RegName(num + 8) : REG_UNDEF;
+RegName RegMc6809::decodeTfmBaseReg(uint8_t num) {
+    num &= 0xF;
+    return num < 5 ? RegName(num) : REG_UNDEF;
 }
 
-bool RegMc6809::isTfmBaseReg(RegName name) const {
-    return encodeTfmBaseReg(name) >= 0;
+bool RegMc6809::isTfmBaseReg(RegName name) {
+    const int8_t num = int8_t(name);
+    return num >= 0 && num < 5;
 }
 
-char RegMc6809::tfmSrcModeChar(uint8_t mode) const {
+uint8_t RegMc6809::encodeTfmBaseReg(RegName name) {
+    return uint8_t(name);
+}
+
+char RegMc6809::tfmSrcModeChar(uint8_t mode) {
     if (mode == 0 || mode == 2) return '+';
     return mode == 1 ? '-' : 0;
 }
 
-char RegMc6809::tfmDstModeChar(uint8_t mode) const {
+char RegMc6809::tfmDstModeChar(uint8_t mode) {
     if (mode == 0 || mode == 3) return '+';
     return mode == 1 ? '-' : 0;
-}
-
-int8_t RegMc6809::encodeTfmBaseReg(RegName name) const {
-    const int8_t num = int8_t(name) - 8;
-    return num >= 0 && num < 5 ? num : -1;
 }
 
 } // namespace mc6809

--- a/src/reg_mc6809.h
+++ b/src/reg_mc6809.h
@@ -23,26 +23,27 @@
 namespace libasm {
 namespace mc6809 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    OFFSET =  1, // Describe offset in indexed addressing
-    REG_PCR = 2, // Program counter relative addressing
-    REG_D =   8+0,
-    REG_X =   8+1,
-    REG_Y =   8+2,
-    REG_U =   8+3,
-    REG_S =   8+4,
-    REG_PC =  8+5,
-    REG_W =   8+6,
-    REG_V =   8+7,
-    REG_A =   8+8,
-    REG_B =   8+9,
-    REG_CC =  8+10,
-    REG_DP =  8+11,
-    REG_Z =   8+12, // "z" zero register
-    REG_0 =   8+13, // "0" zero register
-    REG_E =   8+14,
-    REG_F =   8+15,
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // Data registers.
+    REG_D =   0,
+    REG_X =   1,
+    REG_Y =   2,
+    REG_U =   3,
+    REG_S =   4,
+    REG_PC =  5,
+    REG_W =   6,  // 6309
+    REG_V =   7,  // 6309
+    REG_A =   8,
+    REG_B =   9,
+    REG_CC =  10,
+    REG_DP =  11,
+    REG_Z =   12, // 6309: "z" zero register
+    REG_0 =   13, // 6309: "0" zero register
+    REG_E =   14, // 6309
+    REG_F =   15, // 6309
+    // Other registers.
+    REG_PCR = 0 + 16, // Program counter relative addressing
 };
 
 enum RegSize : uint8_t {
@@ -53,34 +54,33 @@ enum RegSize : uint8_t {
 
 class RegMc6809 : public RegBase {
 public:
-    RegName parseRegName(const char *line) const;
-    uint8_t regNameLen(RegName name) const;
-    RegSize regSize(RegName name) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    static RegSize regSize(RegName name);
     char *outRegName(char *out, const RegName name) const;
 
-    RegName decodeDataReg(uint8_t num) const;
-    int8_t encodeDataReg(RegName ame) const;
+    static RegName decodeDataReg(uint8_t num);
+    static bool isDataReg(RegName name);
+    static uint8_t encodeDataReg(RegName name);
 
-    RegName decodeBaseReg(uint8_t num) const;
-    int8_t encodeBaseReg(RegName name) const;
-    bool isBaseReg(RegName name) const;
+    static RegName decodeBaseReg(uint8_t num);
+    static bool isBaseReg(RegName name);
+    static bool isIndexedBase(RegName name);
+    static bool isIndexReg(RegName name);
+    static uint8_t encodeBaseReg(RegName name);
 
-    int8_t encodeIndexReg(RegName name) const;
-    bool isIndexReg(RegName name) const;
-    bool isIndexedBase(RegName name) const;
+    static RegName decodeStackReg(uint8_t bitPos, bool onUserStack);
+    static uint8_t encodeStackReg(RegName name, bool onUserStack);
 
-    RegName decodeStackReg(uint8_t bitPos, bool onUserStack) const;
-    uint8_t encodeStackReg(RegName name, bool onUserStack) const;
+    static RegName decodeBitOpReg(uint8_t num);
+    static bool isBitOpReg(RegName name);
+    static uint8_t encodeBitOpReg(RegName name);
 
-    RegName decodeBitOpReg(uint8_t num) const;
-    bool isBitOpReg(RegName name) const;
-    int8_t encodeBitOpReg(RegName name) const;
-
-    RegName decodeTfmBaseReg(uint8_t num) const;
-    bool isTfmBaseReg(RegName name) const;
-    char tfmSrcModeChar(uint8_t mode) const;
-    char tfmDstModeChar(uint8_t mode) const;
-    int8_t encodeTfmBaseReg(RegName name) const;
+    static RegName decodeTfmBaseReg(uint8_t num);
+    static bool isTfmBaseReg(RegName name);
+    static uint8_t encodeTfmBaseReg(RegName name);
+    static char tfmSrcModeChar(uint8_t mode);
+    static char tfmDstModeChar(uint8_t mode);
 };
 
 } // namespace mc6809

--- a/src/reg_mos6502.cpp
+++ b/src/reg_mos6502.cpp
@@ -22,35 +22,24 @@
 namespace libasm {
 namespace mos6502 {
 
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
+RegName RegMos6502::parseRegName(const char *line) {
+    const char r = *line++;
+    if (isidchar(*line)) return REG_UNDEF;
+    switch (toupper(r)) {
+    case 'A': return REG_A;
+    case 'X': return REG_X;
+    case 'Y': return REG_Y;
+    case 'S': return REG_S;
+    default:  return REG_UNDEF;
+    }
 }
 
-static bool regCharCaseEqual(char c, char regChar) {
-    return toupper(c) == toupper(regChar);
+uint8_t RegMos6502::regNameLen(RegName name) {
+    return name == REG_UNDEF ? 0 : 1;
 }
 
-uint8_t RegMos6502::regNameLen(RegName regName) const {
-    return regName == REG_UNDEF ? 0 : 1;
-}
-
-bool RegMos6502::compareRegName(const char *line, RegName regName) const {
-    if (!regCharCaseEqual(*line++, char(regName)))
-        return false;
-    return !isidchar(*line);
-}
-
-RegName RegMos6502::parseIndexReg(const char *line) const {
-    if (compareRegName(line, REG_X)) return REG_X;
-    if (compareRegName(line, REG_Y)) return REG_Y;
-    return REG_UNDEF;
-}
-
-char *RegMos6502::outRegName(char *out, const RegName regName) const {
-    const char r = char(regName);
-    *out++ = _uppercase ? r : tolower(r);
-    *out = 0;
-    return out;
+char *RegMos6502::outRegName(char *out, const RegName name) const {
+    return outChar(out, char(name));
 }
 
 } // namespace mos6502

--- a/src/reg_mos6502.h
+++ b/src/reg_mos6502.h
@@ -32,10 +32,9 @@ enum RegName : char {
 
 class RegMos6502 : public RegBase {
 public:
-    uint8_t regNameLen(RegName regName) const;
-    bool compareRegName(const char *line, RegName regName) const;
-    RegName parseIndexReg(const char *line) const;
-    char *outRegName(char *out, const RegName regName) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, const RegName name) const;
 };
 
 } // namespace mos6502

--- a/src/reg_ns32000.h
+++ b/src/reg_ns32000.h
@@ -23,35 +23,38 @@
 namespace libasm {
 namespace ns32000 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_R0 = '0',  // R0
-    REG_R1 = '1',  // R1
-    REG_R2 = '2',  // R2
-    REG_R3 = '3',  // R3
-    REG_R4 = '4',  // R4
-    REG_R5 = '5',  // R5
-    REG_R6 = '6',  // R6
-    REG_R7 = '7',  // R7
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // General registers.
+    REG_R0 = 0 + 0,
+    REG_R1 = 1 + 0,
+    REG_R2 = 2 + 0,
+    REG_R3 = 3 + 0,
+    REG_R4 = 4 + 0,
+    REG_R5 = 5 + 0,
+    REG_R6 = 6 + 0,
+    REG_R7 = 7 + 0,
 #ifdef ENABLE_FLOAT
-    REG_F0 = 'A',  // F0
-    REG_F1 = 'B',  // F1
-    REG_F2 = 'C',  // F2
-    REG_F3 = 'D',  // F3
-    REG_F4 = 'E',  // F4
-    REG_F5 = 'F',  // F5
-    REG_F6 = 'G',  // F6
-    REG_F7 = 'H',  // F7
+    // Floating point registers.
+    REG_F0 = 0 + 8,
+    REG_F1 = 1 + 8,
+    REG_F2 = 2 + 8,
+    REG_F3 = 3 + 8,
+    REG_F4 = 4 + 8,
+    REG_F5 = 5 + 8,
+    REG_F6 = 6 + 8,
+    REG_F7 = 7 + 8,
 #endif
-    REG_FP = 'f',  // FP
-    REG_SP = 's',  // SP
-    REG_SB = 'b',  // SB
-    REG_PC = 'p',  // PC
-    REG_TOS = 't', // TOS
-    REG_EXT = 'e', // EXT
+    REG_FP = 'F',  // FP
+    REG_SP = 'S',  // SP
+    REG_SB = 'B',  // SB
+    REG_PC = 'P',  // PC
+    REG_TOS = 'T', // TOS
+    REG_EXT = 'E', // EXT
 };
 
-enum PregName : uint8_t {
+enum PregName : int8_t {
+    PREG_UNDEF   = -1,
     PREG_UPSR    = 0,  // UPSR/US
     PREG_FP      = 8,  // FP
     PREG_SP      = 9,  // SP
@@ -59,11 +62,11 @@ enum PregName : uint8_t {
     PREG_PSR     = 13, // PSR
     PREG_INTBASE = 14, // INTBASE
     PREG_MOD     = 15, // MOD
-    PREG_UNDEF   = 16,
 };
 
 #ifdef ENABLE_MMU
-enum MregName : uint8_t {
+enum MregName : int8_t {
+    MREG_UNDEF = -1,
     MREG_BPR0  = 0,  // BPR0
     MREG_BPR1  = 1,  // BPR1
     MREG_MSR   = 10, // MSR
@@ -71,7 +74,6 @@ enum MregName : uint8_t {
     MREG_PTB0  = 12, // PTB0
     MREG_PTB1  = 13, // PTB1
     MREG_EIA   = 15, // EIA
-    MREG_UNDEF = 16,
 };
 #endif
 
@@ -85,49 +87,49 @@ enum ConfigName : uint8_t {
 
 enum StrOptName : uint8_t {
     STROPT_UNDEF = 0,
-    STROPT_B = 2,  // Backward
-    STROPT_W = 4,  // While Match
-    STROPT_U = 12, // Until Match
+    STROPT_B     = 0x2,  // Backward
+    STROPT_W     = 0x4,  // While Match
+    STROPT_U     = 0xC, // Until Match
 };
 
 class RegNs32000 : public RegBase {
 public:
-    RegName parseRegName(const char *line) const;
-    RegName decodeRegName(uint8_t num, bool floating = false) const;
-    int8_t encodeRegName(RegName name) const;
-    uint8_t regNameLen(RegName name) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
     char *outRegName(char *out, const RegName name) const;
-    bool isGeneric(RegName name) const;
+    static uint8_t encodeRegName(RegName name);
+    static bool isGeneric(RegName name);
 #ifdef ENABLE_FLOAT
-    bool isFloat(RegName name) const;
+    static RegName decodeRegName(uint8_t num, bool floating = false);
+    static bool isFloat(RegName name);
+#else
+    static RegName decodeRegName(uint8_t num);
 #endif
 
-    PregName parsePregName(const char *line) const;
-    PregName decodePregName(uint8_t num) const;
-    int8_t encodePregName(PregName name) const;
-    uint8_t pregNameLen(PregName name) const;
+    static PregName parsePregName(const char *line);
+    static uint8_t pregNameLen(PregName name);
     char *outPregName(char *out, PregName name) const;
+    static PregName decodePregName(uint8_t num);
+    static uint8_t encodePregName(PregName name);
 
 #ifdef ENABLE_MMU
-    MregName parseMregName(const char *line) const;
-    MregName decodeMregName(uint8_t num) const;
-    int8_t encodeMregName(MregName name) const;
-    uint8_t mregNameLen(MregName name) const;
+    static MregName parseMregName(const char *line);
+    static uint8_t mregNameLen(MregName name);
     char *outMregName(char *out, MregName name) const;
+    static MregName decodeMregName(uint8_t num);
+    static uint8_t encodeMregName(MregName name);
 #endif
 
-    ConfigName parseConfigName(const char *line) const;
-    ConfigName decodeConfigName(uint8_t num) const;
-    uint8_t configNameLen(ConfigName name) const;
-    char *outConfigName(char *out, ConfigName name) const;
+    static ConfigName parseConfigName(const char *line);
+    static uint8_t configNameLen(ConfigName name);
+    char *outConfigNames(char *out, uint8_t configs) const;
 
-    StrOptName parseStrOptName(const char *line) const;
-    StrOptName decodeStrOptName(uint8_t num) const;
-    uint8_t strOptNameLen(StrOptName name) const;
-    char *outStrOptName(char *out, StrOptName name) const;
+    static StrOptName parseStrOptName(const char *line);
+    static uint8_t strOptNameLen(StrOptName name);
+    char *outStrOptNames(char *out, uint8_t strOpts) const;
 
-    OprSize parseIndexSize(const char *line) const;
-    uint8_t indexSizeLen(OprSize size) const;
+    static OprSize parseIndexSize(const char *line);
+    static uint8_t indexSizeLen(OprSize size);
     char indexSizeChar(OprSize size) const;
 };
 

--- a/src/reg_tms9900.cpp
+++ b/src/reg_tms9900.cpp
@@ -22,44 +22,37 @@
 namespace libasm {
 namespace tms9900 {
 
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
-}
-
-uint8_t RegTms9900::regNameLen(RegName regName) const {
-    const char r = char(regName);
-    if (isdigit(r)) return 2;
-    if (isalpha(r)) return 3;
-    return 0;
-}
-
-RegName RegTms9900::parseRegName(const char *line) const {
+RegName RegTms9900::parseRegName(const char *line) {
     if (toupper(*line++) != 'R')
         return REG_UNDEF;
     if (isdigit(*line) && !isidchar(line[1]))
-        return RegName(*line);
+        return RegName(*line - '0');
     if (*line++ == '1' && (*line >= '0' && *line < '6') && !isidchar(line[1]))
-        return RegName('A' + (*line - '0'));
+        return RegName((*line - '0') + 10);
     return REG_UNDEF;
 }
 
-char *RegTms9900::outRegName(char *out, uint8_t regno) const {
-    regno &= 0x0f;
-    *out++ = _uppercase ? 'R' : 'r';
-    if (regno < 10) {
-        *out++ = regno + '0';
+uint8_t RegTms9900::regNameLen(RegName name) {
+    if (name == REG_UNDEF) return 0;
+    const uint8_t r = uint8_t(name);
+    return r < 10 ? 2 : 3;
+}
+
+char *RegTms9900::outRegName(char *out, uint8_t num) const {
+    num &= 0x0f;
+    out = outChar(out, 'R');
+    if (num < 10) {
+        out = outChar(out, '0' + num);
     } else {
-        *out++ = '1';
-        *out++ = regno - 10 + '0';
+        out = outChar(out, '1');
+        out = outChar(out, '0' + num - 10);
     }
     *out = 0;
     return out;
 }
 
-uint16_t RegTms9900::encodeRegNumber(RegName regName) const {
-    const char r = char(regName);
-    if (isdigit(r)) return r - '0';
-    return r - 'A' + 10;
+uint8_t RegTms9900::encodeRegNumber(RegName name) {
+    return uint8_t(name);
 }
 
 } // namespace tms9900

--- a/src/reg_tms9900.h
+++ b/src/reg_tms9900.h
@@ -22,32 +22,33 @@
 namespace libasm {
 namespace tms9900 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_R0 = '0',
-    REG_R1 = '1',
-    REG_R2 = '2',
-    REG_R3 = '3',
-    REG_R4 = '4',
-    REG_R5 = '5',
-    REG_R6 = '6',
-    REG_R7 = '7',
-    REG_R8 = '8',
-    REG_R9 = '9',
-    REG_R10 = 'A',
-    REG_R11 = 'B',
-    REG_R12 = 'C',
-    REG_R13 = 'D',
-    REG_R14 = 'E',
-    REG_R15 = 'F',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    REG_R0 =  0,
+    REG_R1 =  1,
+    REG_R2 =  2,
+    REG_R3 =  3,
+    REG_R4 =  4,
+    REG_R5 =  5,
+    REG_R6 =  6,
+    REG_R7 =  7,
+    REG_R8 =  8,
+    REG_R9 =  9,
+    REG_R10 = 10,
+    REG_R11 = 11,
+    REG_R12 = 12,
+    REG_R13 = 13,
+    REG_R14 = 14,
+    REG_R15 = 15,
 };
 
 class RegTms9900 : public RegBase {
 public:
-    uint8_t regNameLen(RegName regName) const;
-    RegName parseRegName(const char *line) const;
-    char *outRegName(char *out, uint8_t regno) const;
-    uint16_t encodeRegNumber(RegName regName) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, uint8_t num) const;
+
+    static uint8_t encodeRegNumber(RegName name);
 };
 
 } // namespace tms9900

--- a/src/reg_z8.h
+++ b/src/reg_z8.h
@@ -80,40 +80,22 @@ enum CcName : int8_t {
 
 class RegZ8 : public RegBase {
 public:
-    RegZ8();
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, RegName name) const;
+    static bool isPairReg(RegName);
+    static uint8_t encodeRegName(RegName name);
+    static RegName decodeRegNum(uint8_t num);
+    static RegName decodePairRegNum(uint8_t num);
 
-    RegName parseRegName(const char *line) const;
-    static uint8_t regNameLen(RegName regName);
-    static uint8_t encodeRegName(RegName regName);
-    static RegName decodeRegNum(uint8_t regNum, bool pair = false);
-    static bool isRegPair(RegName);
-    char *outRegName(char *out, RegName regName) const;
+    static CcName parseCcName(const char *line);
+    char *outCcName(char *out, CcName name) const;
+    static uint8_t ccNameLen(const CcName name);
+    static uint8_t encodeCcName(CcName name);
+    static CcName decodeCcNum(uint8_t num);
 
-    CcName parseCcName(const char *line) const;
-    static uint8_t ccNameLen(const CcName ccName);
-    static int8_t encodeCcName(CcName ccName);
-    static CcName decodeCcNum(uint8_t ccNum);
-    char *outCcName(char *out, CcName ccName) const;
-
-    bool setRegPointer(int16_t rp);
-    bool setRegPointer0(int16_t rp0);
-    bool setRegPointer1(int16_t rp1);
-    bool isWorkReg(uint8_t regAddr) const;
-    bool isWorkRegAlias(uint8_t regAddr) const;
-    uint8_t encodeWorkRegAddr(RegName regName) const;
-
-private:
-    int16_t _regPointer0;
-    int16_t _regPointer1;
-
-    RegName parseRegName(
-        const char *line, const RegName *table, const RegName *end) const;
-    char regName1stChar(const RegName regName) const;
-    char regName2ndChar(const RegName regName) const;
-    char regName3rdChar(const RegName regName) const;
-    char ccName1stChar(const CcName ccName) const;
-    char ccName2ndChar(const CcName ccName) const;
-    CcName parseCcName(const char *line, int8_t max) const;
+    static bool isWorkRegAlias(uint8_t addr);
+    static uint8_t encodeWorkRegAddr(RegName name);
 };
 
 } // namespace z8

--- a/src/reg_z80.cpp
+++ b/src/reg_z80.cpp
@@ -24,258 +24,114 @@
 namespace libasm {
 namespace z80 {
 
-static constexpr RegName ALL_REGS[] PROGMEM = {
-    REG_AFP, REG_AF, REG_HL, REG_BC, REG_DE, REG_SP, REG_IX, REG_IY,
-    REG_A, REG_B, REG_C, REG_D, REG_E, REG_H, REG_L, REG_I, REG_R,
-    REG_IM,
+static const char TEXT_REG_BC[]  PROGMEM = "BC";
+static const char TEXT_REG_DE[]  PROGMEM = "DE";
+static const char TEXT_REG_HL[]  PROGMEM = "HL";
+static const char TEXT_REG_IX[]  PROGMEM = "IX";
+static const char TEXT_REG_IY[]  PROGMEM = "IY";
+static const char TEXT_REG_SP[]  PROGMEM = "SP";
+static const char TEXT_REG_AFP[] PROGMEM = "AF'";
+static const char TEXT_REG_AF[]  PROGMEM = "AF";
+static const char TEXT_REG_A[]   PROGMEM = "A";
+static const char TEXT_REG_B[]   PROGMEM = "B";
+static const char TEXT_REG_C[]   PROGMEM = "C";
+static const char TEXT_REG_D[]   PROGMEM = "D";
+static const char TEXT_REG_E[]   PROGMEM = "E";
+static const char TEXT_REG_H[]   PROGMEM = "H";
+static const char TEXT_REG_L[]   PROGMEM = "L";
+static const char TEXT_REG_IM[]  PROGMEM = "IM";
+static const char TEXT_REG_R[]   PROGMEM = "R";
+static const char TEXT_REG_I[]   PROGMEM = "I";
+static const RegBase::NameEntry REG_TABLE[] PROGMEM = {
+     NAME_ENTRY(REG_BC)
+     NAME_ENTRY(REG_DE)
+     NAME_ENTRY(REG_HL)
+     NAME_ENTRY(REG_IX)
+     NAME_ENTRY(REG_IY)
+     NAME_ENTRY(REG_SP)
+     NAME_ENTRY(REG_AFP)
+     NAME_ENTRY(REG_AF)
+     NAME_ENTRY(REG_A)
+     NAME_ENTRY(REG_B)
+     NAME_ENTRY(REG_C)
+     NAME_ENTRY(REG_D)
+     NAME_ENTRY(REG_E)
+     NAME_ENTRY(REG_H)
+     NAME_ENTRY(REG_L)
+     NAME_ENTRY(REG_IM)
+     NAME_ENTRY(REG_R)
+     NAME_ENTRY(REG_I)
 };
 
-static constexpr RegName POINTER_REGS[] PROGMEM = {
-    REG_BC, REG_DE, REG_HL, REG_SP
-};
-static constexpr RegName STACK_REGS[] PROGMEM = {
-    REG_BC, REG_DE, REG_HL, REG_AF
-};
-static constexpr RegName INDIRECT_BASES[] PROGMEM = {
-    REG_BC, REG_DE
-};
-static constexpr RegName IR_REGS[] PROGMEM = {
-    REG_I, REG_R
-};
-static constexpr RegName DATA_REGS[] PROGMEM = {
-    REG_B, REG_C, REG_D, REG_E, REG_H, REG_L, REG_UNDEF, REG_A
-};
-
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
+RegName RegZ80::parseRegName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(REG_TABLE));
+    return entry ? RegName(entry->name()) : REG_UNDEF;
 }
 
-static bool regCharCaseEqual(char c, char regChar) {
-    return toupper(c) == toupper(regChar);
+uint8_t RegZ80::regNameLen(RegName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(REG_TABLE));
 }
 
-char RegZ80::regName1stChar(const RegName regName) const {
-    char r = char(regName);
-    if (regName == REG_IX || regName == REG_IY)
-        r = 'I';
-    if (regName == REG_AFP)
-        r = 'A';
-    return _uppercase ? toupper(r) : tolower(r);
-}
-
-char RegZ80::regName2ndChar(const RegName regName) const {
-    char c;
-    switch (regName) {
-    case REG_HL: c = 'L'; break;
-    case REG_BC: c = 'C'; break;
-    case REG_DE: c = 'E'; break;
-    case REG_SP: c = 'P'; break;
-    case REG_AF:
-    case REG_AFP: c = 'F'; break;
-    case REG_IX:
-    case REG_IY: c = char(regName); break;
-    case REG_IM: c = 'M'; break;
-    default: c = 0;
-    }
-    return _uppercase ? toupper(c) : tolower(c);
-}
-
-char RegZ80::regName3rdChar(const RegName regName) const {
-    return regName == REG_AFP ? '\'' : 0;
-}
-
-bool RegZ80::compareRegName(const char *line, RegName regName) const {
-    if (!regCharCaseEqual(*line++, regName1stChar(regName))) return false;
-    const char r2 = regName2ndChar(regName);
-    if (r2 && !regCharCaseEqual(*line++, r2)) return false;
-    const char r3 = regName3rdChar(regName);
-    if (r3 && !regCharCaseEqual(*line++, r3)) return false;
-    return !isidchar(*line);
-}
-
-uint8_t RegZ80::regNameLen(const RegName regName) {
-    if (regName == REG_AFP) return 3;
-    if (isupper(char(regName))) return 1;
-    return 2;
-}
-
-char *RegZ80::outRegName(char *out, const RegName regName) const {
-    *out++ = regName1stChar(regName);
-    const char r2 = regName2ndChar(regName);
-    if (r2) {
-        *out++ = r2;
-        const char r3 = regName3rdChar(regName);
-        if (r3)
-            *out++ = r3;
-    }
-    *out = 0;
+char *RegZ80::outRegName(char *out, RegName name) const {
+    const NameEntry *entry = searchName(uint8_t(name), ARRAY_RANGE(REG_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
     return out;
 }
 
-static constexpr CcName CC8_NAMES[] PROGMEM = {
-    CC_NZ, CC_Z, CC_NC, CC_C, CC_PO, CC_PE, CC_P, CC_M
-};
-
-static bool ccCharCaseEqual(char c, char ccChar) {
-    return toupper(c) == toupper(ccChar);
+OprSize RegZ80::regSize(const RegName name) {
+    return int8_t(name) < 8 ? SZ_WORD : SZ_BYTE;
 }
 
-char RegZ80::ccName1stChar(const CcName ccName) const {
-    char cc = char(ccName);
-    if (islower(cc))
-        cc = (ccName == CC_NZ || ccName == CC_NC) ? 'N' : 'P';
-    return _uppercase ? cc : tolower(cc);
+uint8_t RegZ80::encodeDataReg(RegName name) {
+    // (HL) is parsed as HL_PTR, then looked up as format=REG_8
+    // reg=REG_HL.  So we have to map REG_HL to register number 6
+    // which is encoded by REG_UNDEF in DATA_REG[].
+    if (name == REG_HL) return 6;
+    return int8_t(name) - 8;
 }
 
-char RegZ80::ccName2ndChar(const CcName ccName) const {
-    if (isupper(ccName)) return 0;
-    return _uppercase ? toupper(ccName) : char(ccName);
+RegName RegZ80::decodeDataReg(uint8_t num) {
+    if ((num &= 7) == 6) return REG_UNDEF;
+    return RegName(num + 8);
 }
 
-uint8_t RegZ80::ccNameLen(const CcName ccName) {
-    return isupper(ccName) ? 1 : 2;
+uint8_t RegZ80::encodePointerReg(RegName name) {
+    return int8_t(name);
 }
 
-char *RegZ80::outCcName(char *out, const CcName ccName) const {
-    *out++ = ccName1stChar(ccName);
-    const char c2 = ccName2ndChar(ccName);
-    if (c2) *out++ = c2;
-    *out = 0;
-    return out;
+uint8_t RegZ80::encodePointerRegIx(RegName name, RegName ix) {
+    return encodePointerReg(name == ix ? REG_HL : name);
 }
 
-bool RegZ80::compareCcName(const char *line, CcName ccName) const {
-    if (!ccCharCaseEqual(*line++, ccName1stChar(ccName))) return false;
-    const char c2 = ccName2ndChar(ccName);
-    if (c2 && !ccCharCaseEqual(*line++, c2)) return false;
-    return !isalpha(*line);
+RegName RegZ80::decodePointerReg(uint8_t num, const InsnZ80 *insn) {
+    const RegName name = RegName(num & 3);
+    if (insn && name == REG_HL) return decodeIndexReg(*insn);
+    return name;
 }
 
-char *RegZ80::outCc4Name(char *out, const Config::opcode_t cc4) const {
-    const CcName cc = CcName(pgm_read_byte(&CC8_NAMES[cc4 & 3]));
-    return outCcName(out, cc);
+uint8_t RegZ80::encodeStackReg(RegName name) {
+    if (name == REG_AF) return 3;
+    return uint8_t(name);
 }
 
-char *RegZ80::outCc8Name(char *out, const Config::opcode_t cc8) const {
-    const CcName cc = CcName(pgm_read_byte(&CC8_NAMES[cc8 & 7]));
-    return outCcName(out, cc);
+RegName RegZ80::decodeStackReg(uint8_t num) {
+    if ((num &= 3) == 3) return REG_AF;
+    return RegName(num);
 }
 
-CcName RegZ80::parseCcName(const char *line, int8_t max) const {
-    for (int8_t cc = 0; cc < max; cc++) {
-        const CcName ccName = CcName(pgm_read_byte(&CC8_NAMES[cc]));
-        if (compareCcName(line, ccName))
-            return ccName;
-    }
-    return CC_UNDEF;
+uint8_t RegZ80::encodeIndirectBase(RegName name) {
+    return uint8_t(name);
 }
 
-CcName RegZ80::parseCc4Name(const char *line) const {
-    return parseCcName(line, 4);
-}
-
-CcName RegZ80::parseCc8Name(const char *line) const {
-    return parseCcName(line, 8);
-}
-
-int8_t RegZ80::encodeCcName(const CcName ccName) {
-    for (int8_t cc = 0; cc < 8; cc++) {
-        if (CcName(pgm_read_byte(&CC8_NAMES[cc])) == ccName)
-            return cc;
-    }
-    return -1;
-}
-
-static int8_t encodeRegNumber(
-    RegName regName, const RegName *table, const RegName *end) {
-    for (const RegName *p = table; p < end; p++) {
-        if (pgm_read_byte(p) == regName) return p - table;
-    }
-    return -1;
-}
-
-RegName RegZ80::parseRegName(
-    const char *line, const RegName *table, const RegName *end) const {
-    for (const RegName *p = table; p < end; p++) {
-        const RegName regName = RegName(pgm_read_byte(p));
-        if (compareRegName(line, regName)) return regName;
-    }
-    return REG_UNDEF;
-}
-
-OprSize RegZ80::registerSize(const RegName regName) {
-    switch (regName) {
-    case REG_BC: case REG_DE: case REG_HL:
-    case REG_SP: case REG_IX: case REG_IY:
-    case REG_AF: case REG_AFP:
-        return SZ_WORD;
-    case REG_B: case REG_C: case REG_D: case REG_E:
-    case REG_H: case REG_L: case REG_A:
-    case REG_I: case REG_R: case REG_IM:
-        return SZ_BYTE;
-    default:
-        return SZ_NONE;
-    }
-}
-
-static RegName decodeRegNumber(
-    const uint8_t regNum, const RegName *table, const RegName *end) {
-    const RegName *entry = &table[regNum];
-    return entry < end ? RegName(pgm_read_byte(entry)) : REG_UNDEF;
-}
-
-RegName RegZ80::parseRegister(const char *line) const {
-    return parseRegName(line, ARRAY_RANGE(ALL_REGS));
-}
-
-int8_t RegZ80::encodePointerReg(RegName regName) {
-    return encodeRegNumber(regName, ARRAY_RANGE(POINTER_REGS));
-}
-
-int8_t RegZ80::encodePointerRegIx(RegName regName, RegName ix) {
-    if (regName == ix) regName = REG_HL;
-    return encodeRegNumber(regName, ARRAY_RANGE(POINTER_REGS));
-}
-
-int8_t RegZ80::encodeStackReg(RegName regName) {
-    return encodeRegNumber(regName, ARRAY_RANGE(STACK_REGS));
-}
-
-int8_t RegZ80::encodeIndirectBase(RegName regName) {
-    return encodeRegNumber(regName, ARRAY_RANGE(INDIRECT_BASES));
+RegName RegZ80::decodeIndirectBase(uint8_t num) {
+    return RegName(num & 1);
 }
 
 void RegZ80::encodeIndexReg(InsnZ80 &insn, RegName ixReg) {
     const Config::opcode_t prefix =
         (ixReg == REG_IX) ? TableZ80::PREFIX_IX : TableZ80::PREFIX_IY;
     insn.setOpCode(insn.opCode(), prefix);
-}
-
-int8_t RegZ80::encodeIrReg(RegName regName) {
-    return encodeRegNumber(regName, ARRAY_RANGE(IR_REGS));
-}
-
-int8_t RegZ80::encodeDataReg(RegName regName) {
-    // (HL) is parsed as HL_PTR, then looked up as format=REG_8
-    // reg=REG_HL.  So we have to map REG_HL to register number 6
-    // which is encoded by REG_UNDEF in DATA_REG[].
-    if (regName == REG_HL) regName = REG_UNDEF;
-    return encodeRegNumber(regName, ARRAY_RANGE(DATA_REGS));
-}
-
-RegName RegZ80::decodePointerReg(uint8_t regNum, const InsnZ80 *insn) {
-    const RegName regName =
-        decodeRegNumber(regNum & 3, ARRAY_RANGE(POINTER_REGS));
-    if (insn == nullptr || regName != REG_HL) return regName;
-    return decodeIndexReg(*insn);
-}
-
-RegName RegZ80::decodeStackReg(uint8_t regNum) {
-    return decodeRegNumber(regNum & 3, ARRAY_RANGE(STACK_REGS));
-}
-
-RegName RegZ80::decodeIndirectBase(uint8_t regNum) {
-    return decodeRegNumber(regNum & 1, ARRAY_RANGE(INDIRECT_BASES));
 }
 
 RegName RegZ80::decodeIndexReg(const InsnZ80 &insn) {
@@ -285,12 +141,60 @@ RegName RegZ80::decodeIndexReg(const InsnZ80 &insn) {
     return REG_UNDEF;
 }
 
-RegName RegZ80::decodeIrReg(uint8_t regNum) {
-    return decodeRegNumber(regNum & 1, ARRAY_RANGE(IR_REGS));
+uint8_t RegZ80::encodeIrReg(RegName name) {
+    return uint8_t(name) - 16;
 }
 
-RegName RegZ80::decodeDataReg(uint8_t regNum) {
-    return decodeRegNumber(regNum & 7, ARRAY_RANGE(DATA_REGS));
+RegName RegZ80::decodeIrReg(uint8_t num) {
+    return RegName((num & 1) + 16);
+}
+
+static const char TEXT_CC_NZ[] PROGMEM = "NZ";
+static const char TEXT_CC_Z[]  PROGMEM = "Z";
+static const char TEXT_CC_NC[] PROGMEM = "NC";
+static const char TEXT_CC_C[]  PROGMEM = "C";
+static const char TEXT_CC_PO[] PROGMEM = "PO";
+static const char TEXT_CC_PE[] PROGMEM = "PE";
+static const char TEXT_CC_P[]  PROGMEM = "P";
+static const char TEXT_CC_M[]  PROGMEM = "M";
+static const RegBase::NameEntry CC_TABLE[] PROGMEM = {
+    NAME_ENTRY(CC_NZ)
+    NAME_ENTRY(CC_Z)
+    NAME_ENTRY(CC_NC)
+    NAME_ENTRY(CC_C)
+    NAME_ENTRY(CC_PO)
+    NAME_ENTRY(CC_PE)
+    NAME_ENTRY(CC_P)
+    NAME_ENTRY(CC_M)
+};
+
+CcName RegZ80::parseCcName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(CC_TABLE));
+    return entry ? CcName(entry->name()) : CC_UNDEF;
+}
+
+uint8_t RegZ80::ccNameLen(const CcName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(CC_TABLE));
+}
+
+char *RegZ80::outCcName(char *out, const CcName name) const {
+    const NameEntry *entry = searchName(uint8_t(name), ARRAY_RANGE(CC_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
+    return out;
+}
+
+bool RegZ80::isCc4Name(CcName name) {
+    const int8_t num = int8_t(name);
+    return num >= 0 && num < 4;
+}
+
+uint8_t RegZ80::encodeCcName(const CcName name) {
+    return uint8_t(name);
+}
+
+CcName RegZ80::decodeCcName(uint8_t num) {
+    return CcName(num & 7);
 }
 
 } // namespace z80

--- a/src/reg_z80.cpp
+++ b/src/reg_z80.cpp
@@ -248,7 +248,7 @@ int8_t RegZ80::encodeIndirectBase(RegName regName) {
 void RegZ80::encodeIndexReg(InsnZ80 &insn, RegName ixReg) {
     const Config::opcode_t prefix =
         (ixReg == REG_IX) ? TableZ80::PREFIX_IX : TableZ80::PREFIX_IY;
-    insn.setInsnCode(prefix, insn.opCode());
+    insn.setOpCode(insn.opCode(), prefix);
 }
 
 int8_t RegZ80::encodeIrReg(RegName regName) {
@@ -279,7 +279,7 @@ RegName RegZ80::decodeIndirectBase(uint8_t regNum) {
 }
 
 RegName RegZ80::decodeIndexReg(const InsnZ80 &insn) {
-    const Config::opcode_t prefix = insn.prefixCode();
+    const Config::opcode_t prefix = insn.prefix();
     if (prefix == TableZ80::PREFIX_IX) return REG_IX;
     if (prefix == TableZ80::PREFIX_IY) return REG_IY;
     return REG_UNDEF;

--- a/src/reg_z80.h
+++ b/src/reg_z80.h
@@ -23,83 +23,79 @@
 namespace libasm {
 namespace z80 {
 
-enum RegName : char {
-    REG_UNDEF = 0,
-    REG_HL = 'h',
-    REG_BC = 'b',
-    REG_DE = 'd',
-    REG_SP = 's',
-    REG_AF = 'a',
-    REG_AFP = 'f',              // AF'
-    REG_IX = 'x',
-    REG_IY = 'y',
-    REG_B = 'B',
-    REG_C = 'C',
-    REG_D = 'D',
-    REG_E = 'E',
-    REG_H = 'H',
-    REG_L = 'L',
-    REG_A = 'A',
-    REG_I = 'I',
-    REG_R = 'R',
+enum RegName : int8_t {
+    REG_UNDEF = -1,
+    // 16-bit registers
+    // Pointer registers
+    REG_BC  = 0 + 0,
+    REG_DE  = 1 + 0,
+    REG_HL  = 2 + 0,
+    REG_SP  = 3 + 0,
+    REG_IX  = 4 + 0,
+    REG_IY  = 5 + 0,
+    REG_AF  = 6 + 0,
+    REG_AFP = 7 + 0,
+    // 8-bit registers
+    // Data registers
+    REG_B = 0 + 8,
+    REG_C = 1 + 8,
+    REG_D = 2 + 8,
+    REG_E = 3 + 8,
+    REG_H = 4 + 8,
+    REG_L = 5 + 8,
+    REG_A = 7 + 8,
+    // Other registers
+    REG_I  = 0 + 16,
+    REG_R  = 1 + 16,
     // 8085
-    REG_IM = 'i',
+    REG_IM = 0 + 18,
 };
 
-enum CcName : char {
-    CC_UNDEF = 0,
-    CC_Z  = 'Z',
-    CC_NZ = 'z',
-    CC_C  = 'C',
-    CC_NC = 'c',
-    CC_PO = 'o',
-    CC_PE = 'e',
-    CC_P  = 'P',
-    CC_M  = 'M',
+enum CcName : int8_t {
+    CC_UNDEF = -1,
+    CC_NZ = 0,
+    CC_Z  = 1,
+    CC_NC = 2,
+    CC_C  = 3,
+    CC_PO = 4,
+    CC_PE = 5,
+    CC_P  = 6,
+    CC_M  = 7,
 };
 
 class RegZ80 : public RegBase {
 public:
-    CcName parseCc4Name(const char *line) const;
-    CcName parseCc8Name(const char *line) const;
-    bool compareRegName(const char *line, RegName regName) const;
-    static uint8_t ccNameLen(const CcName ccName);
-    static int8_t encodeCcName(CcName ccName);
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(const RegName name);
+    char *outRegName(char *out, const RegName name) const;
+    static OprSize regSize(const RegName name);
 
-    RegName parseRegister(const char *line) const;
-    static OprSize registerSize(const RegName regName);
-    static uint8_t regNameLen(const RegName regName);
-    static int8_t encodePointerReg(RegName regName);
-    static int8_t encodePointerRegIx(RegName regName, RegName ix);
-    static int8_t encodeStackReg(RegName regName);
-    static int8_t encodeIndirectBase(RegName regName);
-    static void encodeIndexReg(InsnZ80 &insn, RegName ixReg);
-    static int8_t encodeIrReg(RegName regName);
-    static int8_t encodeDataReg(RegName regName);
+    static uint8_t encodeDataReg(RegName name);
+    static RegName decodeDataReg(uint8_t num);
 
+    static uint8_t encodePointerReg(RegName name);
+    static uint8_t encodePointerRegIx(RegName name, RegName ix);
     static RegName decodePointerReg(
-        uint8_t regNum, const InsnZ80 *insn = nullptr);
-    static RegName decodeStackReg(uint8_t regNum);
-    static RegName decodeIndirectBase(uint8_t regNum);
+        uint8_t num, const InsnZ80 *insn = nullptr);
+
+    static uint8_t encodeStackReg(RegName name);
+    static RegName decodeStackReg(uint8_t num);
+
+    static uint8_t encodeIndirectBase(RegName name);
+    static RegName decodeIndirectBase(uint8_t num);
+
+    static void encodeIndexReg(InsnZ80 &insn, RegName ixReg);
     static RegName decodeIndexReg(const InsnZ80 &insn);
-    static RegName decodeIrReg(uint8_t regNum);
-    static RegName decodeDataReg(uint8_t regNum);
 
-    char *outRegName(char *out, const RegName regName) const;
-    char *outCc4Name(char *out, Config::opcode_t cc4) const;
-    char *outCc8Name(char *out, Config::opcode_t cc8) const;
+    static uint8_t encodeIrReg(RegName name);
+    static RegName decodeIrReg(uint8_t num);
 
-private:
-    RegName parseRegName(
-        const char *line, const RegName *table, const RegName *end) const;
-    char regName1stChar(const RegName regName) const;
-    char regName2ndChar(const RegName regName) const;
-    char regName3rdChar(const RegName regName) const;
-    char ccName1stChar(const CcName ccName) const;
-    char ccName2ndChar(const CcName ccName) const;
-    char *outCcName(char *out, CcName ccName) const;
-    bool compareCcName(const char *line, CcName ccName) const;
-    CcName parseCcName(const char *line, int8_t max) const;
+    static CcName parseCcName(const char *line);
+    static uint8_t ccNameLen(const CcName name);
+    char *outCcName(char *out, CcName cc) const;
+    static bool isCc4Name(CcName name);
+    static uint8_t encodeCcName(CcName name);
+    static CcName decodeCcName(uint8_t num);
 };
 
 } // namespace z80

--- a/src/reg_z8000.cpp
+++ b/src/reg_z8000.cpp
@@ -23,20 +23,16 @@
 namespace libasm {
 namespace z8000 {
 
-static bool isidchar(const char c) {
-    return isalnum(c) || c == '_';
-}
-
 static int8_t parseRegNum(const char *line) {
-    if (isdigit(*line) && !isidchar(line[1]))
+    if (isdigit(*line) && !RegBase::isidchar(line[1]))
         return *line - '0';
     if (*line++ == '1'
-        && *line >= '0' && *line < '6' && !isidchar(line[1]))
+        && *line >= '0' && *line < '6' && !RegBase::isidchar(line[1]))
         return *line - '0' + 10;
     return -1;
 }
 
-RegName RegZ8000::parseRegName(const char *line) const {
+RegName RegZ8000::parseRegName(const char *line) {
     if (toupper(*line++) == 'R') {
         const char type = toupper(*line);
         if (type == 'H' || type == 'L' || type == 'R' || type == 'Q')
@@ -56,87 +52,22 @@ RegName RegZ8000::parseRegName(const char *line) const {
     return REG_UNDEF;
 }
 
-uint8_t RegZ8000::regNameLen(RegName regName) const {
-    if (isCtlReg(regName)) return ctlRegLen(regName);
-    const int8_t num = int8_t(regName);
+uint8_t RegZ8000::regNameLen(RegName name) {
+    if (isCtlReg(name)) return ctlRegLen(name);
+    const int8_t num = int8_t(name);
     if (num < 0) return 0;
-    if (isByteReg(regName)) return 3;
-    const uint8_t len = isWordReg(regName) ? 1 : 2;
+    if (isByteReg(name)) return 3;
+    const uint8_t len = isWordReg(name) ? 1 : 2;
     return len + ((num & 0xF) < 10 ? 1 : 2);
 }
 
-uint8_t RegZ8000::encodeRegName(RegName regName) const {
-    const int8_t num = int8_t(regName);
-    if (isByteReg(regName)) return num - 16;
-    if (isLongReg(regName)) return num - 32;
-    if (isQuadReg(regName)) return num - 48;
-    return num;
-}
-
-RegName RegZ8000::decodeRegNum(uint8_t regNum, OprSize size) const {
-    switch (size) {
-    case SZ_BYTE: return decodeByteReg(regNum);
-    case SZ_WORD: return decodeWordReg(regNum);
-    case SZ_LONG: return decodeLongReg(regNum);
-    case SZ_QUAD: return decodeQuadReg(regNum);
-    case SZ_ADDR: return TableZ8000.segmentedModel()
-            ? decodeLongReg(regNum) : decodeWordReg(regNum);
-    default: return REG_UNDEF;
-    }
-}
-
-RegName RegZ8000::decodeWordReg(uint8_t regNum) const {
-    regNum &= 0x0f;
-    return RegName(regNum);
-}
-
-RegName RegZ8000::decodeByteReg(uint8_t regNum) const {
-    regNum &= 0x0f;
-    return RegName(regNum + 16);
-}
-
-RegName RegZ8000::decodeLongReg(uint8_t regNum) const {
-    regNum &= 0x0f;
-    return regNum % 2 == 0 ? RegName(regNum + 32) : REG_ILLEGAL;
-}
-
-RegName RegZ8000::decodeQuadReg(uint8_t regNum) const {
-    regNum &= 0x0f;
-    return regNum % 4 == 0 ? RegName(regNum + 48) : REG_ILLEGAL;
-}
-
-bool RegZ8000::isWordReg(RegName regName) const {
-    const int8_t r = static_cast<int8_t>(regName);
-    return r >= 0 && r < 16;
-}
-
-bool RegZ8000::isByteReg(RegName regName) const {
-    const int8_t r = static_cast<int8_t>(regName);
-    return r >= 16 && r < 16 + 16;
-}
-
-bool RegZ8000::isLongReg(RegName regName) const {
-    const int8_t r = static_cast<int8_t>(regName);
-    return r >= 32 && r < 32 + 16;
-}
-
-bool RegZ8000::isQuadReg(RegName regName) const {
-    const int8_t r = static_cast<int8_t>(regName);
-    return r >= 48 && r < 48 + 16;
-}
-
-bool RegZ8000::isCtlReg(RegName regName) const {
-    const int8_t r = static_cast<int8_t>(regName);
-    return r >= 64 && r < 64 + 8;
-}
-
-char *RegZ8000::outRegName(char *out, RegName regName) const {
-    int8_t num = int8_t(regName);
+char *RegZ8000::outRegName(char *out, RegName name) const {
+    int8_t num = int8_t(name);
     if (num < 0) return out;
-    if (isCtlReg(regName)) return outCtlName(out, regName);
+    if (isCtlReg(name)) return outCtlName(out, name);
 
     out = outChar(out, 'R');
-    if (isByteReg(regName)) {
+    if (isByteReg(name)) {
         num -= 16;
         if (num < 8) {
             out = outChar(out, 'H');
@@ -144,10 +75,10 @@ char *RegZ8000::outRegName(char *out, RegName regName) const {
             num -= 8;
             out = outChar(out, 'L');
         }
-    } else if (isLongReg(regName)) {
+    } else if (isLongReg(name)) {
         num -= 32;
         out = outChar(out, 'R');
-    } else if (isQuadReg(regName)) {
+    } else if (isQuadReg(name)) {
         num -= 48;
         out = outChar(out, 'Q');
     }
@@ -160,44 +91,66 @@ char *RegZ8000::outRegName(char *out, RegName regName) const {
     return out;
 }
 
-struct NameEntry {
-    uint8_t name;
-    uint8_t codeAndLen;
-    const char *text;
+uint8_t RegZ8000::encodeGeneralRegName(RegName name) {
+    return uint8_t(name) & 0xF;
+}
 
-    static const NameEntry *searchName(
-            uint8_t name, const NameEntry *begin, const NameEntry *end) {
-        for (const NameEntry *entry = begin; entry < end; entry++) {
-            const uint8_t n = pgm_read_byte(&entry->name);
-            if (name == n) return entry;
-        }
-        return nullptr;
+RegName RegZ8000::decodeRegNum(uint8_t num, OprSize size) {
+    switch (size) {
+    case SZ_BYTE: return decodeByteReg(num);
+    case SZ_WORD: return decodeWordReg(num);
+    case SZ_LONG: return decodeLongReg(num);
+    case SZ_QUAD: return decodeQuadReg(num);
+    case SZ_ADDR: return TableZ8000.segmentedModel()
+            ? decodeLongReg(num) : decodeWordReg(num);
+    default: return REG_UNDEF;
     }
-    static const NameEntry *searchCode(
-            uint8_t code, const NameEntry *begin, const NameEntry *end) {
-        for (const NameEntry *entry = begin; entry < end; entry++) {
-            const uint8_t c = (pgm_read_byte(&entry->codeAndLen) >> 4);
-            if (code == c) return entry;
-        }
-        return nullptr;
-    }
-    static const NameEntry *searchText(
-            const char *str, const NameEntry *begin, const NameEntry *end) {
-        for (const NameEntry *entry = begin; entry < end; entry++) {
-            const char *text = reinterpret_cast<const char *>(
-                    pgm_read_ptr(&entry->text));
-            const uint8_t len = pgm_read_byte(&entry->codeAndLen) & 0xF;
-            if (strncasecmp_P(str, text, len) == 0 && !isidchar(str[len]))
-                return entry;
-        }
-        return nullptr;
-    }
-    static uint8_t nameLen(
-            uint8_t name, const NameEntry *begin, const NameEntry *end) {
-        const NameEntry *entry = searchName(name, begin, end);
-        return entry ? (pgm_read_byte(&entry->codeAndLen) & 0xF) : 0;
-    }
-};
+}
+
+RegName RegZ8000::decodeWordReg(uint8_t num) {
+    num &= 0x0f;
+    return RegName(num);
+}
+
+RegName RegZ8000::decodeByteReg(uint8_t num) {
+    num &= 0x0f;
+    return RegName(num + 16);
+}
+
+RegName RegZ8000::decodeLongReg(uint8_t num) {
+    num &= 0x0f;
+    return num % 2 == 0 ? RegName(num + 32) : REG_ILLEGAL;
+}
+
+RegName RegZ8000::decodeQuadReg(uint8_t num) {
+    num &= 0x0f;
+    return num % 4 == 0 ? RegName(num + 48) : REG_ILLEGAL;
+}
+
+bool RegZ8000::isWordReg(RegName name) {
+    const int8_t r = static_cast<int8_t>(name);
+    return r >= 0 && r < 16;
+}
+
+bool RegZ8000::isByteReg(RegName name) {
+    const int8_t r = static_cast<int8_t>(name);
+    return r >= 16 && r < 16 + 16;
+}
+
+bool RegZ8000::isLongReg(RegName name) {
+    const int8_t r = static_cast<int8_t>(name);
+    return r >= 32 && r < 32 + 16;
+}
+
+bool RegZ8000::isQuadReg(RegName name) {
+    const int8_t r = static_cast<int8_t>(name);
+    return r >= 48 && r < 48 + 16;
+}
+
+bool RegZ8000::isCtlReg(RegName name) {
+    const int8_t r = static_cast<int8_t>(name);
+    return r >= 64 && r < 64 + 8;
+}
 
 static const char TEXT_REG_FLAGS[]   PROGMEM = "FLAGS";
 static const char TEXT_REG_FCW[]     PROGMEM = "FCW";
@@ -206,86 +159,73 @@ static const char TEXT_REG_PSAPSEG[] PROGMEM = "PSAPSEG";
 static const char TEXT_REG_PSAPOFF[] PROGMEM = "PSAPOFF";
 static const char TEXT_REG_NSPSEG[] PROGMEM  = "NSPSEG";
 static const char TEXT_REG_NSPOFF[] PROGMEM  = "NSPOFF";
-static const NameEntry CTL_TABLE[] PROGMEM = {
-    { REG_FLAGS,   0x15, TEXT_REG_FLAGS   },
-    { REG_FCW,     0x23, TEXT_REG_FCW     },
-    { REG_REFRESH, 0x37, TEXT_REG_REFRESH },
-    { REG_PSAPSEG, 0x47, TEXT_REG_PSAPSEG },
-    { REG_PSAPOFF, 0x57, TEXT_REG_PSAPOFF },
-    { REG_NSPSEG,  0x66, TEXT_REG_NSPSEG  },
-    { REG_NSPOFF,  0x76, TEXT_REG_NSPOFF  },
+static const RegBase::NameEntry CTL_TABLE[] PROGMEM = {
+    NAME_ENTRY(REG_FLAGS)
+    NAME_ENTRY(REG_FCW)
+    NAME_ENTRY(REG_REFRESH)
+    NAME_ENTRY(REG_PSAPSEG)
+    NAME_ENTRY(REG_PSAPOFF)
+    NAME_ENTRY(REG_NSPSEG)
+    NAME_ENTRY(REG_NSPOFF)
 };
 
-RegName RegZ8000::parseCtlReg(const char *line) const {
-    const NameEntry *entry =
-        NameEntry::searchText(line, ARRAY_RANGE(CTL_TABLE));
-    return entry ? RegName(pgm_read_byte(&entry->name)) : REG_UNDEF;
+RegName RegZ8000::parseCtlReg(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(CTL_TABLE));
+    return entry ? RegName(entry->name()) : REG_UNDEF;
 }
 
-RegName RegZ8000::decodeCtlReg(uint8_t ctlNum) const {
-    const NameEntry *entry =
-        NameEntry::searchCode(ctlNum & 7, ARRAY_RANGE(CTL_TABLE));
-    return entry ? RegName(pgm_read_byte(&entry->name)) : REG_ILLEGAL;
+uint8_t RegZ8000::ctlRegLen(RegName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(CTL_TABLE));
 }
 
-uint8_t RegZ8000::ctlRegLen(RegName regName) const {
-    return NameEntry::nameLen(regName, ARRAY_RANGE(CTL_TABLE));
-}
-
-char *RegZ8000::outCtlName(char *out, RegName regName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(regName, ARRAY_RANGE(CTL_TABLE));
-    if (entry) {
-        const char *text = reinterpret_cast<const char *>(
-                pgm_read_ptr(&entry->text));
-        out = outText(out, text);
-    }
+char *RegZ8000::outCtlName(char *out, RegName name) const {
+    const NameEntry *entry = searchName(uint8_t(name), ARRAY_RANGE(CTL_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
     return out;
 }
 
-int8_t RegZ8000::encodeCtlReg(RegName ctlReg) const {
-    const NameEntry *entry =
-        NameEntry::searchName(ctlReg, ARRAY_RANGE(CTL_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) >> 4) : -1;
+RegName RegZ8000::decodeCtlReg(uint8_t num) {
+    num &= 7;
+    if (num == 0) return REG_ILLEGAL;
+    return RegName(num + 64);
 }
 
-static const char TEXT_IT_VI[] PROGMEM  = "VI";
-static const char TEXT_IT_NVI[] PROGMEM = "NVI";
-static const NameEntry IT_TABLE[] PROGMEM = {
-    { IT_NVI, 0x13, TEXT_IT_NVI },
-    { IT_VI,  0x22, TEXT_IT_VI  },
+uint8_t RegZ8000::encodeCtlReg(RegName name) {
+    return uint8_t(name) - 64;
+}
+
+static const char TEXT_INTR_VI[] PROGMEM  = "VI";
+static const char TEXT_INTR_NVI[] PROGMEM = "NVI";
+static const RegBase::NameEntry INTR_TABLE[] PROGMEM = {
+    NAME_ENTRY(INTR_NVI)
+    NAME_ENTRY(INTR_VI)
 };
 
-char *RegZ8000::outIntrNames(char *out, uint8_t intrNames) const {
+IntrName RegZ8000::parseIntrName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(INTR_TABLE));
+    return entry ? IntrName(entry->name()) : INTR_UNDEF;
+}
+
+uint8_t RegZ8000::intrNameLen(IntrName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(INTR_TABLE));
+}
+
+char *RegZ8000::outIntrNames(char *out, uint8_t intrs) const {
     char c = 0;
-    if ((intrNames & int8_t(IT_VI)) == 0) {
-        out = outText(out, TEXT_IT_VI);
+    if ((intrs & int8_t(INTR_VI)) == 0) {
+        out = outText(out, TEXT_INTR_VI);
         c = ',';
     }
-    if ((intrNames & int8_t(IT_NVI)) == 0) {
+    if ((intrs & int8_t(INTR_NVI)) == 0) {
         if (c) *out++ = c;
-        out = outText(out, TEXT_IT_NVI);
+        out = outText(out, TEXT_INTR_NVI);
     }
-    *out = 0;
     return out;
 }
 
-IntrName RegZ8000::parseIntrName(const char *p) const {
-    const NameEntry *entry =
-        NameEntry::searchText(p, ARRAY_RANGE(IT_TABLE));
-    return entry ? IntrName(pgm_read_byte(&entry->name)) : IT_UNDEF;
-}
-
-uint8_t RegZ8000::intrNameLen(IntrName intrName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(intrName, ARRAY_RANGE(IT_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) & 0xF) : 0;
-}
-
-uint8_t RegZ8000::encodeIntrName(IntrName intrName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(intrName, ARRAY_RANGE(IT_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) >> 4) : 0;
+uint8_t RegZ8000::encodeIntrName(IntrName name) {
+    return uint8_t(name);
 }
 
 static const char TEXT_CC_F[]   PROGMEM = "F";
@@ -308,107 +248,93 @@ static const char TEXT_CC_EQ[]  PROGMEM = "EQ";
 static const char TEXT_CC_ULT[] PROGMEM = "ULT";
 static const char TEXT_CC_NE[]  PROGMEM = "NE";
 static const char TEXT_CC_UGE[] PROGMEM = "UGE";
-static const NameEntry CC_TABLE[] PROGMEM = {
-    { CC_F,   0x01, TEXT_CC_F   },
-    { CC_LT,  0x12, TEXT_CC_LT  },
-    { CC_LE,  0x22, TEXT_CC_LE  },
-    { CC_ULE, 0x33, TEXT_CC_ULE },
-    { CC_OV,  0x42, TEXT_CC_OV  },
-    { CC_MI,  0x52, TEXT_CC_MI  },
-    { CC_Z,   0x61, TEXT_CC_Z   },
-    { CC_C,   0x71, TEXT_CC_C   },
-    { CC_GE,  0x92, TEXT_CC_GE  },
-    { CC_GT,  0xA2, TEXT_CC_GT  },
-    { CC_UGT, 0xB3, TEXT_CC_UGT },
-    { CC_NOV, 0xC3, TEXT_CC_NOV },
-    { CC_PL,  0xD2, TEXT_CC_PL  },
-    { CC_NZ,  0xE2, TEXT_CC_NZ  },
-    { CC_NC,  0xF2, TEXT_CC_NC  },
-    { CC_EQ,  0x62, TEXT_CC_EQ  },
-    { CC_ULT, 0x73, TEXT_CC_ULT },
-    { CC_NE,  0xE2, TEXT_CC_NE  },
-    { CC_UGE, 0xF3, TEXT_CC_UGE },
-    { CC_T,   0x80, TEXT_CC_T   },
+static const RegBase::NameEntry CC_TABLE[] PROGMEM = {
+    NAME_ENTRY(CC_F)
+    NAME_ENTRY(CC_LT)
+    NAME_ENTRY(CC_LE)
+    NAME_ENTRY(CC_ULE)
+    NAME_ENTRY(CC_OV)
+    NAME_ENTRY(CC_MI)
+    NAME_ENTRY(CC_Z)
+    NAME_ENTRY(CC_C)
+    NAME_ENTRY(CC_GE)
+    NAME_ENTRY(CC_GT)
+    NAME_ENTRY(CC_UGT)
+    NAME_ENTRY(CC_NOV)
+    NAME_ENTRY(CC_PL)
+    NAME_ENTRY(CC_NZ)
+    NAME_ENTRY(CC_NC)
+    // Aliases
+    NAME_ENTRY(CC_EQ)
+    NAME_ENTRY(CC_ULT)
+    NAME_ENTRY(CC_NE)
+    NAME_ENTRY(CC_UGE)
+    // Empty text.
+    NAME_ENTRY(CC_T)
 };
 
-CcName RegZ8000::parseCcName(const char *line) const {
-    const NameEntry *entry =
-        NameEntry::searchText(line, ARRAY_RANGE(CC_TABLE));
-    const CcName cc = entry ? CcName(pgm_read_byte(&entry->name)) : CC_UNDEF;
-    return cc == CC_T ? CC_UNDEF : cc;
+CcName RegZ8000::parseCcName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(CC_TABLE));
+    const CcName name = entry ? CcName(entry->name()) : CC_UNDEF;
+    return name == CC_T ? CC_UNDEF : name;
 }
 
-uint8_t RegZ8000::ccNameLen(const CcName ccName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(ccName, ARRAY_RANGE(CC_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) & 0xF) : 0;
+uint8_t RegZ8000::ccNameLen(const CcName name) {
+    return nameLen(uint8_t(name), ARRAY_RANGE(CC_TABLE));
 }
 
-int8_t RegZ8000::encodeCcName(CcName ccName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(ccName, ARRAY_RANGE(CC_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) >> 4) : -1;
+uint8_t RegZ8000::encodeCcName(CcName name) {
+    return uint8_t(name) & 0xF;
 }
 
-CcName RegZ8000::decodeCcNum(uint8_t ccNum) const {
-    const NameEntry *entry =
-        NameEntry::searchCode(ccNum & 0xF, ARRAY_RANGE(CC_TABLE));
-    return entry ? CcName(pgm_read_byte(&entry->name)) : CC_UNDEF;
+CcName RegZ8000::decodeCcNum(uint8_t num) {
+    return CcName(num & 0xF);
 }
 
-char *RegZ8000::outCcName(char *out, CcName ccName) const {
-    const NameEntry *entry =
-        NameEntry::searchName(ccName, ARRAY_RANGE(CC_TABLE));
-    const char *text =
-        reinterpret_cast<const char *>(pgm_read_ptr(&entry->text));
-    return outText(out, text);
+char *RegZ8000::outCcName(char *out, CcName name) const {
+    const NameEntry *entry = searchName(uint8_t(name), ARRAY_RANGE(CC_TABLE));
+    if (entry)
+        out = outText(out, entry->text());
+    return out;
 }
 
-static const char TEXT_FL_C[] PROGMEM = "C";
-static const char TEXT_FL_Z[] PROGMEM = "Z";
-static const char TEXT_FL_S[] PROGMEM = "S";
-static const char TEXT_FL_P[] PROGMEM = "P";
-static const char TEXT_FL_V[] PROGMEM = "V";
-static const NameEntry FLAG_TABLE[] PROGMEM = {
-    { FL_C, 0x81, TEXT_FL_C },
-    { FL_Z, 0x41, TEXT_FL_Z },
-    { FL_S, 0x21, TEXT_FL_S },
-    { FL_P, 0x11, TEXT_FL_P },
-    { FL_V, 0x11, TEXT_FL_V },
+static const char TEXT_FLAG_C[] PROGMEM = "C";
+static const char TEXT_FLAG_Z[] PROGMEM = "Z";
+static const char TEXT_FLAG_S[] PROGMEM = "S";
+static const char TEXT_FLAG_P[] PROGMEM = "P";
+static const char TEXT_FLAG_V[] PROGMEM = "V";
+static const RegBase::NameEntry FLAG_TABLE[] PROGMEM = {
+    NAME_ENTRY(FLAG_C)
+    NAME_ENTRY(FLAG_Z)
+    NAME_ENTRY(FLAG_S)
+    NAME_ENTRY(FLAG_P)
+    NAME_ENTRY(FLAG_V)
 };
+
+FlagName RegZ8000::parseFlagName(const char *line) {
+    const NameEntry *entry = searchText(line, ARRAY_RANGE(FLAG_TABLE));
+    return entry ? FlagName(entry->name()) : FLAG_UNDEF;
+}
+
+uint8_t RegZ8000::flagNameLen(FlagName name) {
+    return name == FLAG_UNDEF ? 0 : 1;
+}
 
 char *RegZ8000::outFlagNames(char *out, uint8_t flags) const {
-    char c = 0;
+    char sep = 0;
     for (uint8_t bit = 0x8; bit; bit >>= 1) {
         if (flags & bit) {
-            if (c) *out++ = c;
-            c = ',';
-            const NameEntry *entry =
-                NameEntry::searchCode(bit, ARRAY_RANGE(FLAG_TABLE));
-            if (entry) {
-                const char *text = reinterpret_cast<const char *>(
-                        pgm_read_ptr(&entry->text));
-                out = outText(out, text);
-            }
+            if (sep) *out++ = sep;
+            sep = ',';
+            const NameEntry *entry = searchName(bit, ARRAY_RANGE(FLAG_TABLE));
+            out = outText(out, entry->text());
         }
     }
     return out;
 }
 
-FlagName RegZ8000::parseFlagName(const char *p) const {
-    const NameEntry *entry =
-        NameEntry::searchText(p, ARRAY_RANGE(FLAG_TABLE));
-    return entry ? FlagName(pgm_read_byte(&entry->name)) : FL_UNDEF;
-}
-
-uint8_t RegZ8000::flagNameLen(FlagName flag) const {
-    return flag == FL_UNDEF ? 0 : 1;
-}
-
-uint8_t RegZ8000::encodeFlagName(FlagName flag) const {
-    const NameEntry *entry =
-        NameEntry::searchName(flag, ARRAY_RANGE(FLAG_TABLE));
-    return entry ? (pgm_read_byte(&entry->codeAndLen) >> 4) : 0;
+uint8_t RegZ8000::encodeFlagName(FlagName name) {
+    return uint8_t(name) & 0xF;
 }
 
 } // namespace z8000

--- a/src/reg_z8000.h
+++ b/src/reg_z8000.h
@@ -103,69 +103,68 @@ enum CcName : int8_t {
     CC_NZ  = 14, // Not zero
     CC_NC  = 15, // No carry
     // Alias
-    CC_EQ  = 16,  // Z: Equal
-    CC_ULT = 17,  // C: Unsigned less than
-    CC_NE  = 18,  // NZ: Nor equal
-    CC_UGE = 19,  // NC: Unsigned greater than or equal
+    CC_EQ  = 6+16,   // Z: Equal
+    CC_ULT = 7+16,   // C: Unsigned less than
+    CC_NE  = 14+16,  // NZ: Nor equal
+    CC_UGE = 15+16,  // NC: Unsigned greater than or equal
 };
 
 enum FlagName : int8_t {
-    FL_UNDEF = 0,
-    FL_C = 8,  // Carry
-    FL_Z = 4,  // Zero
-    FL_S = 2,  // Sign
-    FL_P = 1,  // Parity
+    FLAG_UNDEF = 0,
+    FLAG_C = 8,  // Carry
+    FLAG_Z = 4,  // Zero
+    FLAG_S = 2,  // Sign
+    FLAG_P = 1,  // Parity
     // Alias
-    FL_V = 16, // Overflow
+    FLAG_V = 1+16, // Overflow
 };
 
 enum IntrName : int8_t {
-    IT_UNDEF = 0,
-    IT_NVI = 1, // Non-Vectored Interrupt
-    IT_VI  = 2, // Vectored Interrupt
+    INTR_UNDEF = 0,
+    INTR_NVI = 1, // Non-Vectored Interrupt
+    INTR_VI  = 2, // Vectored Interrupt
 };
 
 class RegZ8000 : public RegBase {
 public:
-    RegName parseRegName(const char *line) const;
-    uint8_t regNameLen(RegName regName) const;
-    uint8_t encodeRegName(RegName regName) const;
-    RegName decodeRegNum(uint8_t regNum, OprSize size) const;
-    RegName decodeByteReg(uint8_t regNum) const;
-    RegName decodeWordReg(uint8_t regNum) const;
-    RegName decodeLongReg(uint8_t regNum) const;
-    RegName decodeQuadReg(uint8_t regNum) const;
-    bool isByteReg(RegName) const;
-    bool isWordReg(RegName) const;
-    bool isLongReg(RegName) const;
-    bool isQuadReg(RegName) const;
-    char *outRegName(char *out, RegName regName) const;
+    static RegName parseRegName(const char *line);
+    static uint8_t regNameLen(RegName name);
+    char *outRegName(char *out, RegName name) const;
+    static uint8_t encodeGeneralRegName(RegName name);
+    static RegName decodeRegNum(uint8_t num, OprSize size);
+    static RegName decodeByteReg(uint8_t num);
+    static RegName decodeWordReg(uint8_t num);
+    static RegName decodeLongReg(uint8_t num);
+    static RegName decodeQuadReg(uint8_t num);
+    static bool isByteReg(RegName name);
+    static bool isWordReg(RegName name);
+    static bool isLongReg(RegName name);
+    static bool isQuadReg(RegName name);
 
-    RegName parseCtlReg(const char *line) const;
-    RegName decodeCtlReg(uint8_t ctlNum) const;
-    bool isCtlReg(RegName) const;
-    int8_t encodeCtlReg(RegName ctlReg) const;
+    static RegName parseCtlReg(const char *line);
+    static RegName decodeCtlReg(uint8_t num);
+    static bool isCtlReg(RegName name);
+    static uint8_t encodeCtlReg(RegName name);
 
-    CcName parseCcName(const char *line) const;
-    uint8_t ccNameLen(const CcName ccName) const;
-    int8_t encodeCcName(CcName ccName) const;
-    CcName decodeCcNum(uint8_t ccNum) const;
-    char *outCcName(char *out, CcName ccName) const;
+    static CcName parseCcName(const char *line);
+    static uint8_t ccNameLen(const CcName name);
+    char *outCcName(char *out, CcName name) const;
+    static uint8_t encodeCcName(CcName name);
+    static CcName decodeCcNum(uint8_t num);
 
-    char *outFlagNames(char *out, uint8_t flagNames) const;
-    FlagName parseFlagName(const char *line) const;
-    uint8_t flagNameLen(FlagName flag) const;
-    uint8_t encodeFlagName(FlagName flag) const;
+    static FlagName parseFlagName(const char *line);
+    static uint8_t flagNameLen(FlagName name);
+    char *outFlagNames(char *out, uint8_t flags) const;
+    static uint8_t encodeFlagName(FlagName name);
 
-    char *outIntrNames(char *out, uint8_t intrNames) const;
-    IntrName parseIntrName(const char *line) const;
-    uint8_t intrNameLen(IntrName intrName) const;
-    uint8_t encodeIntrName(IntrName intrName) const;
+    static IntrName parseIntrName(const char *line);
+    static uint8_t intrNameLen(IntrName name);
+    char *outIntrNames(char *out, uint8_t intrs) const;
+    static uint8_t encodeIntrName(IntrName name);
 
 private:
-    char *outCtlName(char *out, RegName regName) const;
-    uint8_t ctlRegLen(RegName) const;
-    bool compareText(const char *p, const char *text) const;
+    char *outCtlName(char *out, RegName name) const;
+    static uint8_t ctlRegLen(RegName name);
 };
 
 } // namespace z8000

--- a/src/table_base.h
+++ b/src/table_base.h
@@ -29,7 +29,7 @@ public:
     virtual bool setCpu(const char *cpu) = 0;
     virtual const char *getCpu() const = 0;
     Error getError() const { return _error.getError(); }
-    
+
 protected:
     mutable ErrorReporter _error;
 
@@ -76,10 +76,6 @@ protected:
             }
         }
         return nullptr;
-    }
-
-    static void setName(Insn &insn, const char *name, uint8_t max) {
-        strncpy_P(insn._name, name, max + 1);
     }
 };
 

--- a/src/table_cdp1802.cpp
+++ b/src/table_cdp1802.cpp
@@ -150,9 +150,9 @@ Error TableCdp1802::searchOpCode(InsnCdp1802 &insn) const {
     if (!entry) return _error.setError(UNKNOWN_INSTRUCTION);
     insn.setFlags(pgm_read_byte(&entry->flags));
     if (insn.addrMode() == UNDF) return _error.setError(UNKNOWN_INSTRUCTION);
-    const char *name =
+    const /*PROGMEM*/ char *name =
         reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-    TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+    insn.setName_P(name);
     return _error.setOK();
 }
 

--- a/src/table_i8051.cpp
+++ b/src/table_i8051.cpp
@@ -194,9 +194,9 @@ Error TableI8051::searchOpCode(InsnI8051 &insn) const {
             opCode, ARRAY_RANGE(TABLE_I8051), tableCode);
     if (!entry) return _error.setError(UNKNOWN_INSTRUCTION);
     insn.setFlags(pgm_read_word(&entry->flags));
-    const char *name =
+    const /*PROGMEM*/ char *name =
         reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-    TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+    insn.setName_P(name);
     return _error.setOK();
 }
 

--- a/src/table_i8080.cpp
+++ b/src/table_i8080.cpp
@@ -175,9 +175,9 @@ Error TableI8080::searchOpCode(
             insn.opCode(), table, end, tableCode);
         if (entry) {
             insn.setFlags(pgm_read_byte(&entry->flags));
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_i8086.cpp
+++ b/src/table_i8086.cpp
@@ -531,9 +531,9 @@ Error TableI8086::searchOpCode(
             insn.opCode(), table, end, maskCode);
         if (entry) {
             insn.setFlags(pgm_read_dword(&entry->flags));
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_ins8060.cpp
+++ b/src/table_ins8060.cpp
@@ -125,9 +125,9 @@ Error TableIns8060::searchOpCode(InsnIns8060 &insn) const {
     if (!entry) return _error.setError(UNKNOWN_INSTRUCTION);
     insn.setFlags(pgm_read_byte(&entry->flags));
     if (insn.addrMode() == UNDEF) return _error.setError(UNKNOWN_INSTRUCTION);
-    const char *name =
+    const /*PROGMEM*/ char *name =
         reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-    TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+    insn.setName_P(name);
     return _error.setOK();
 }
 

--- a/src/table_ins8070.cpp
+++ b/src/table_ins8070.cpp
@@ -166,9 +166,9 @@ Error TableIns8070::searchOpCode(InsnIns8070 &insn) const {
     if (!entry) return _error.setError(UNKNOWN_INSTRUCTION);
     insn.setFlags(pgm_read_word(&entry->flags));
     if (insn.addrMode() == UNDEF) return _error.setError(UNKNOWN_INSTRUCTION);
-    const char *name =
+    const /*PROGMEM*/ char *name =
         reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-    TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+    insn.setName_P(name);
     return _error.setOK();
 }
 

--- a/src/table_mc6800.cpp
+++ b/src/table_mc6800.cpp
@@ -393,12 +393,9 @@ static constexpr Config::opcode_t PREFIX_P18 = 0x18;
 static constexpr Config::opcode_t PREFIX_P1A = 0x1A;
 static constexpr Config::opcode_t PREFIX_PCD = 0xCD;
 
-bool TableMc6800::isPrefixCode(Config::opcode_t opCode) const {
-    if (_cpuType == MC68HC11) {
-        return opCode == PREFIX_P18 || opCode == PREFIX_P1A
-            || opCode == PREFIX_PCD;
-    }
-    return false;
+bool TableMc6800::isPrefix(Config::opcode_t opCode) const {
+    if (_cpuType != MC68HC11) return false;
+    return opCode == PREFIX_P18 || opCode == PREFIX_P1A || opCode == PREFIX_PCD;
 }
 
 struct TableMc6800::EntryPage {
@@ -478,9 +475,9 @@ const Entry *TableMc6800::searchOpCode(
             insn.opCode(), table, end);
         if (entry) {
             insn.setFlags(pgm_read_word(&entry->flags));
-            const char *name =
+            const/*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return entry;
         }
     }
@@ -503,9 +500,9 @@ Error TableMc6800::searchOpCodeAlias(InsnMc6800 &insn) const {
     if (pgm_read_byte(&entry->opCode) != insn.opCode())
         return _error.setError(INTERNAL_ERROR);
     insn.setFlags(pgm_read_word(&entry->flags));
-    const char *name =
+    const /*PROGMEM*/ char *name =
         reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-    TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+    insn.setName_P(name);
     return _error.setOK();
 }
 

--- a/src/table_mc6800.h
+++ b/src/table_mc6800.h
@@ -32,7 +32,7 @@ public:
     Error searchName(InsnMc6800 &insn) const;
     Error searchOpCode(InsnMc6800 &insn) const;
     Error searchOpCodeAlias(InsnMc6800 &insn) const;
-    bool isPrefixCode(Config::opcode_t opCode) const;
+    bool isPrefix(Config::opcode_t opCode) const;
 
     const char *listCpu() const override;
     bool setCpu(const char *cpu) override;

--- a/src/table_mc68000.cpp
+++ b/src/table_mc68000.cpp
@@ -250,7 +250,7 @@ static bool acceptMode(AddrMode opr, AddrMode table) {
             || table == M_WADDR || table == M_WDATA
             || table == M_RMEM  || table == M_WMEM
             || table == M_IADDR;
-    if (opr == M_PDEC)        
+    if (opr == M_PDEC)
         return table == M_RADDR || table == M_RDATA
             || table == M_WADDR || table == M_WDATA
             || table == M_RMEM  || table == M_WMEM
@@ -362,9 +362,9 @@ Error TableMc68000::searchOpCode(InsnMc68000 &insn) const {
         opCode, ARRAY_RANGE(MC68000_TABLE), maskCode);
     if (entry) {
         insn.setFlags(pgm_read_dword(&entry->flags));
-        const char *name =
+        const /*PROGMEM*/ char *name =
             reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-        TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+        insn.setName_P(name);
         return _error.setOK();
     }
     return _error.setError(UNKNOWN_INSTRUCTION);

--- a/src/table_mc6809.h
+++ b/src/table_mc6809.h
@@ -48,7 +48,7 @@ public:
     const char *getCpu() const override;
     CpuType cpuType() const { return _cpuType; }
 
-    static bool isPrefixCode(Config::opcode_t opCode);
+    static bool isPrefix(Config::opcode_t opCode);
 
     struct EntryPage;
     struct PostEntry;

--- a/src/table_mos6502.cpp
+++ b/src/table_mos6502.cpp
@@ -441,9 +441,9 @@ Error TableMos6502::searchOpCode(
             insn.setFlags(pgm_read_byte(&entry->flags));
             if (!acceptAddrMode(insn.addrMode(), useIndirectLong))
                 continue;
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_ns32000.cpp
+++ b/src/table_ns32000.cpp
@@ -556,12 +556,13 @@ Error TableNs32000::searchOpCode(
         if (entry) {
             insn.setFlags(pgm_read_dword(&entry->flags));
             if (post) {
-                if (insn.readPost(memory)) return NO_MEMORY;
+                insn.readPost(memory);
+                if (_error.setError(insn)) return getError();
                 insn.setHasPost();
             }
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_tms9900.cpp
+++ b/src/table_tms9900.cpp
@@ -193,9 +193,9 @@ Error TableTms9900::searchOpCode(
             insn.opCode(), table, end, maskCode);
         if (entry) {
             insn.setFlags(pgm_read_byte(&entry->flags));
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_z8.cpp
+++ b/src/table_z8.cpp
@@ -352,13 +352,15 @@ Error TableZ8::searchOpCode(
              entry++) {
             insn.setFlags(pgm_read_word(&entry->flags));
             if (insn.postFormat()) {
-                if (insn.length() < 2 && insn.readPost(memory))
-                    return NO_MEMORY;
+                if (insn.length() < 2) {
+                    insn.readPost(memory);
+                    if (insn.getError()) return NO_MEMORY;
+                }
                 if (!matchPostByte(insn)) continue;
             }
-            const char *name =
+            const /*PROGMEM*/ char *name =
                 reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-            TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+            insn.setName_P(name);
             return OK;
         }
     }

--- a/src/table_z80.h
+++ b/src/table_z80.h
@@ -36,7 +36,7 @@ public:
     const char *getCpu() const override;
     CpuType cpuType() const { return _cpuType; }
 
-    static bool isPrefixCode(Config::opcode_t opCode);
+    bool isPrefix(Config::opcode_t opCode) const;
 
     static constexpr Config::opcode_t PREFIX_IX = 0xDD;
     static constexpr Config::opcode_t PREFIX_IY = 0xFD;

--- a/src/table_z8000.cpp
+++ b/src/table_z8000.cpp
@@ -348,15 +348,16 @@ const Entry *TableZ8000::searchOpCode(
          entry++) {
         insn.setFlags(pgm_read_dword(&entry->flags));
         if (insn.hasPost()) {
-            if (insn.length() < 4 && insn.readPost(memory)) {
-                _error.setError(NO_MEMORY);
-                return nullptr;
+            if (insn.length() < 4) {
+                insn.readPost(memory);
+                if (_error.setError(insn))
+                    return nullptr;
             }
             if (!matchPostWord(insn)) continue;
         }
-        const char *name =
+        const /*PROGMEM*/ char *name =
             reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-        TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+        insn.setName_P(name);
         return entry;
     }
     return nullptr;
@@ -372,9 +373,9 @@ Error TableZ8000::searchOpCodeAlias(InsnZ8000 &insn, DisMemory &memory) const {
     if (entry) {
         entry++;
         insn.setFlags(pgm_read_dword(&entry->flags));
-        const char *name =
+        const /*PROGMEM*/ char *name =
             reinterpret_cast<const char *>(pgm_read_ptr(&entry->name));
-        TableBase::setName(insn.insn(), name, Config::NAME_MAX);
+        insn.setName_P(name);
     }
     return _error.setError(entry ? OK : UNKNOWN_INSTRUCTION);
 }

--- a/src/table_z8000.cpp
+++ b/src/table_z8000.cpp
@@ -82,8 +82,8 @@ static const Entry Z8000_TABLE[] PROGMEM = {
     E(0x7B09, 0x0000, NONE, MRES,   M_NO,   M_NO,   NO, NO)
     E(0x7B0A, 0x0000, NONE, MBIT,   M_NO,   M_NO,   NO, NO)
     E(0x7B0D, 0x00F0, WORD, MREQ,   M_R,    M_NO,   C4, NO)
-    E(0x7C00, 0x0003, NONE, DI,     M_INTT, M_NO,   C0, NO)
-    E(0x7C04, 0x0003, NONE, EI,     M_INTT, M_NO,   C0, NO)
+    E(0x7C00, 0x0003, NONE, DI,     M_INTR, M_NO,   C0, NO)
+    E(0x7C04, 0x0003, NONE, EI,     M_INTR, M_NO,   C0, NO)
     E(0x7D00, 0x00F7, WORD, LDCTL,  M_R,    M_CTL,  C4, C0)
     E(0x7D08, 0x00F7, WORD, LDCTL,  M_CTL,  M_R,    C0, C4)
     E(0x7F00, 0x00FF, NONE, SC,     M_IM8,  M_NO,   C0, C0)
@@ -294,7 +294,7 @@ static bool acceptMode(AddrMode opr, AddrMode table) {
     if (opr == M_X)
         return table == M_GENI || table == M_GEND || table == M_GENA;
     if (opr == M_CC) return table == M_FLAG; // C & Z
-    if (opr == M_NO) return table == M_CC || table == M_INTT || table == M_FLAG;
+    if (opr == M_NO) return table == M_CC || table == M_INTR || table == M_FLAG;
     return false;
 }
 

--- a/src/text_tms9900.h
+++ b/src/text_tms9900.h
@@ -69,7 +69,6 @@ static const char TEXT_LI[]   PROGMEM = "LI";
 static const char TEXT_LIMI[] PROGMEM = "LIMI";
 static const char TEXT_LREX[] PROGMEM = "LREX";
 static const char TEXT_LWPI[] PROGMEM = "LWPI";
-static const char TEXT_MID[]  PROGMEM = "MID";
 static const char TEXT_MOV[]  PROGMEM = "MOV";
 static const char TEXT_MOVB[] PROGMEM = "MOVB";
 static const char TEXT_MPY[]  PROGMEM = "MPY";

--- a/test/gen_mos6502.asm
+++ b/test/gen_mos6502.asm
@@ -13,7 +13,7 @@
       ASL  >$000F
       ASL  $0100
       BPL  *+19
-      BPL  *-25
+      BPL  *-$7E
       BPL  *
       ORA  ($12),Y
       ORA  $16,X
@@ -41,7 +41,7 @@
       ROL  >$002F
       ROL  $0100
       BMI  *+$33
-      BMI  *-$5C
+      BMI  *-$7E
       BMI  *
       AND  ($32),Y
       AND  $36,X

--- a/test/gen_r65c02.asm
+++ b/test/gen_r65c02.asm
@@ -18,7 +18,7 @@
       ASL  $0100
       BBR0 $10,*+3
       BPL  *+19
-      BPL  *-$26
+      BPL  *-$7E
       BPL  *
       ORA  ($12),Y
       ORA  ($13)

--- a/test/gen_w65c02s.asm
+++ b/test/gen_w65c02s.asm
@@ -18,7 +18,7 @@
       ASL  $0100
       BBR0 $10,*+3
       BPL  *+19
-      BPL  *-$26
+      BPL  *-$7E
       BPL  *
       ORA  ($12),Y
       ORA  ($13)

--- a/test/gen_w65c816.asm
+++ b/test/gen_w65c816.asm
@@ -22,7 +22,7 @@
       ORA  >>$001110
       ORA  $010010
       BPL  *+19
-      BPL  *-$30
+      BPL  *-$7E
       BPL  *
       ORA  ($12),Y
       ORA  ($13)

--- a/test/gen_w65sc02.asm
+++ b/test/gen_w65sc02.asm
@@ -16,7 +16,7 @@
       ASL  >$000F
       ASL  $0100
       BPL  *+19
-      BPL  *-$21
+      BPL  *-$7E
       BPL  *
       ORA  ($12),Y
       ORA  ($13)
@@ -49,7 +49,7 @@
       ROL  >$002F
       ROL  $0100
       BMI  *+$33
-      BMI  *-$6F
+      BMI  *-$7E
       BMI  *
       AND  ($32),Y
       AND  ($33)

--- a/test/test_asm_ins8060.cpp
+++ b/test/test_asm_ins8060.cpp
@@ -108,7 +108,7 @@ static void test_jump() {
 
     ATEST(0x1000, "JMP label1000",    0x90, 0xFE);
     EATEST(OPERAND_TOO_FAR, 0x1000, "JMP label0FF0");
-    
+
     TEST("JMP E(PC)",        0x90, 0x80);
     TEST("JMP disp0x7F(P1)", 0x91, 0x7F);
     TEST("JMP disp0x81(P2)", 0x92, 0x81);
@@ -228,7 +228,7 @@ static void test_undefined_symbol() {
 static void test_error() {
     ETEST(UNDEFINED_SYMBOL, "LD (P3)", 0xC0, 0x00);
     ETEST(UNDEFINED_SYMBOL, "LD (E)",  0xC0, 0x00);
-    ETEST(UNKNOWN_OPERAND, "LD 1(E)");
+    ETEST(UNKNOWN_OPERAND,  "LD 1(E)");
     ETEST(MISSING_CLOSING_PAREN, "LD 1(P3");
     ETEST(ILLEGAL_CONSTANT, "LDI #1");
 }

--- a/test/test_asm_ins8070.cpp
+++ b/test/test_asm_ins8070.cpp
@@ -365,7 +365,7 @@ static void test_error() {
     ETEST(ILLEGAL_CONSTANT, "LD A,@=1");
     ETEST(MISSING_COMMA,    "LD A,1(P3)");  // SC/MP style
     ETEST(MISSING_COMMA,    "LD A,@1(P3)"); // SC/MP style
-    ETEST(UNKNOWN_OPERAND,  "LD A,1,(EA)");
+    ETEST(GARBAGE_AT_END,   "LD A,1,(EA)");
 }
 
 void run_tests() {

--- a/test/test_asm_mos6502.cpp
+++ b/test/test_asm_mos6502.cpp
@@ -239,7 +239,7 @@ static void test_imm() {
         // W65C816
         TEST("REP #zero10", 0xC2, 0x10);
         TEST("SEP #zeroFF", 0xE2, 0xFF);
-    }        
+    }
 }
 
 static void test_zpg() {
@@ -648,8 +648,8 @@ static void test_abs_indexed_idir() {
         TEST("JSR ($1235,X)",    0xFC, 0x35, 0x12);
         TEST("JSR (>abs0010,X)", 0xFC, 0x10, 0x00);
     } else {
-        ETEST(OPERAND_NOT_ALLOWED, "JSR ($1235,X)");
-        ETEST(UNKNOWN_OPERAND, "JSR (>abs0010),X");
+        ETEST(OPERAND_NOT_ALLOWED,  "JSR ($1235,X)");
+        ETEST(REGISTER_NOT_ALLOWED, "JSR (>abs0010),X");
     }
 }
 
@@ -958,31 +958,31 @@ static void test_undefined_symbol() {
 
 static void test_error() {
     if (w65c816()) {
-        ETEST(UNKNOWN_OPERAND, "SBC [$10],X");
-        ETEST(UNKNOWN_OPERAND, "ORAL ($10),X");
-        ETEST(UNKNOWN_OPERAND, "ORA ($10,S),X");
-        ETEST(UNKNOWN_OPERAND, "ORA ($10,X),X");
-        ETEST(UNKNOWN_OPERAND, "ORA ($10,X),Y");
-        ETEST(UNKNOWN_OPERAND, "ORA ($10,Y),X");
-        ETEST(UNKNOWN_OPERAND, "ORA ($10,Y),Y");
-        ETEST(OPERAND_NOT_ALLOWED, "ORA $123456,Y");
+        ETEST(REGISTER_NOT_ALLOWED, "SBC  [$10],X");
+        ETEST(REGISTER_NOT_ALLOWED, "ORAL ($10),X");
+        ETEST(REGISTER_NOT_ALLOWED, "ORA  ($10,S),X");
+        ETEST(REGISTER_NOT_ALLOWED, "ORA  ($10,X),X");
+        ETEST(REGISTER_NOT_ALLOWED, "ORA  ($10,X),Y");
+        ETEST(REGISTER_NOT_ALLOWED, "ORA  ($10,Y),X");
+        ETEST(REGISTER_NOT_ALLOWED, "ORA  ($10,Y),Y");
+        ETEST(OPERAND_NOT_ALLOWED,  "ORA  $123456,Y");
     }
-    ETEST(UNKNOWN_OPERAND, "ORA ($10,Y)");
-    ETEST(UNKNOWN_OPERAND, "ORA ($10),X");
+    ETEST(REGISTER_NOT_ALLOWED, "ORA ($10,Y)");
+    ETEST(REGISTER_NOT_ALLOWED, "ORA ($10),X");
     if (m6502()) {
         // MOS6502
-        ETEST(UNKNOWN_OPERAND, "JSR ($1234,Y)");
-        ETEST(OPERAND_NOT_ALLOWED, "JSR ($1234,X)");
-        ETEST(UNKNOWN_OPERAND, "JMP ($1234,Y)");
+        ETEST(REGISTER_NOT_ALLOWED, "JSR ($1234,Y)");
+        ETEST(OPERAND_NOT_ALLOWED,  "JSR ($1234,X)");
+        ETEST(REGISTER_NOT_ALLOWED, "JMP ($1234,Y)");
     } else if (w65c816()) {
         // W65C816
-        ETEST(UNKNOWN_OPERAND, "JMP ($1234,Y)");
-        ETEST(UNKNOWN_OPERAND, "JSR ($1234,Y)");
+        ETEST(REGISTER_NOT_ALLOWED, "JMP ($1234,Y)");
+        ETEST(REGISTER_NOT_ALLOWED, "JSR ($1234,Y)");
     } else {
         // W65SC02
-        ETEST(UNKNOWN_OPERAND, "JSR ($1234,Y)");
-        ETEST(OPERAND_NOT_ALLOWED, "JSR ($1234,X)");
-        ETEST(UNKNOWN_OPERAND, "JMP ($1234,Y)");
+        ETEST(REGISTER_NOT_ALLOWED, "JSR ($1234,Y)");
+        ETEST(OPERAND_NOT_ALLOWED,  "JSR ($1234,X)");
+        ETEST(REGISTER_NOT_ALLOWED, "JMP ($1234,Y)");
     }
 }
 


### PR DESCRIPTION
This reduces ROM and RAM usage on AVR Arduino.

```
    CPU       FLASH          RAM
asm cdp1802   12388 ( -30)   353 (  0)
asm i8051     14064 (-296)   353 ( -1)
asm i8080     12986 (-374)   358 ( -1)
asm i8086     17538 (  70)   353 ( -1)
asm ins8060   12192 (-188)   353 ( -1)
asm ins8070   13060 (-169)   354 (  0)
asm mc6800    14924 (-108)   358 ( -1)
asm mc68000   16824 (-138)   354 (  0)
asm mc6809    18756 (  33)   359 ( -1)
asm mos6502   15813 (  95)   363 ( -1)
asm ns32000   18595 (-102)   353 ( -1)
asm tms9900   14554 ( -78)   358 ( -1)
asm z8        17042 (-224)   363 (  0)
asm z80       15574 (-742)   358 ( -1)
asm z8000     18556 (-336)   354 ( -1)
dis cdp1802   10104 ( -46)   293 (  0)
dis i8051     11524 (-348)   293 (  0)
dis i8080     10853 (-215)   298 (  0)
dis i8086     14893 (-278)   294 (  0)
dis ins8060   10600 (-122)   293 (  0)
dis ins8070   11261 (-244)   294 (  0)
dis mc6800    13374 (-104)   298 (  0)
dis mc68000   15135 (-377)   294 (  0)
dis mc6809    15491 (-402)   298 (  0)
dis mos6502   13589 (-234)   301 (  0)
dis ns32000   16555 (-450)   293 (  0)
dis tms9900   11868 (-170)   298 (  0)
dis z8        14778 (-376)   299 ( -4)
dis z80       14096 (-712)   298 (  0)
dis z8000     16262 (-548)   295 (  0)
```