### PR TITLE
[fixed64] Narrow round_off indices to uint_fast8_t

### DIFF
--- a/src/fixed64.cpp
+++ b/src/fixed64.cpp
@@ -192,9 +192,9 @@ bool __fixed64::round_off(uint_fast8_t bits) {
         // no need to round
         return false;
     }
-    const auto lsb = FULL_BITS - bits;  // least significand bit
-    const auto roundb = lsb - 1;        // round bit
-    const auto roundi = roundb / _BITS;
+    const uint_fast8_t lsb = FULL_BITS - bits;  // least significand bit
+    const uint_fast8_t roundb = lsb - 1;        // round bit
+    const uint_fast8_t roundi = roundb / _BITS;
     const auto roundm = UINT16_C(1) << (roundb % _BITS);
     if (_v[roundi] & roundm) {
         auto intermediate = true;
@@ -204,7 +204,7 @@ bool __fixed64::round_off(uint_fast8_t bits) {
         }
         if ((_v[roundi] & (roundm - 1)) != 0)
             intermediate = false;
-        const auto lsbi = lsb / _BITS;
+        const uint_fast8_t lsbi = lsb / _BITS;
         const auto lsbm = UINT16_C(1) << (lsb % _BITS);
         const auto even = (_v[lsbi] & lsbm) == 0;
         if (!intermediate || !even) {


### PR DESCRIPTION
Resolves the two high-severity CodeQL `cpp/comparison-with-wider-type` alerts at
`src/fixed64.cpp:201` and `:219`.

Both loops in `__fixed64::round_off` compare a `uint_fast8_t` counter against
`roundi`, which was `int` because `_BITS`/`_MSW` are `constexpr auto` integers and
the arithmetic chain promotes.

The alerts are false positives -- `roundi` is bounded by the guard at the top of
the function:

| Expression | Range |
|---|---|
| `FULL_BITS = _BITS * (_MSW + 1)` | 80 |
| guard `bits >= FULL_BITS \|\| bits == 0` returns early | `bits` in [1, 79] |
| `lsb = FULL_BITS - bits` | [1, 79] |
| `roundb = lsb - 1` | [0, 78] |
| `roundi = roundb / _BITS` | [0, 4] |

`_v[]` has `_SIZE = 6` elements, so indexing stays in bounds, and every caller
passes `MANT_DIG` in {8, 24, 53, 56, 64}.

Rather than widening the counters, this narrows the intermediates so counter and
bound share a type. That keeps the arithmetic 8-bit, which matters on the AVR
targets this library ships to; promoting the loops to `int` would cost cycles and
flash there.

Semantically a no-op: all values are provably in [0, 79], so nothing truncates and
results are bit-identical. Disassembler output is unchanged, so no autogen
regeneration is needed.

Explicit types instead of `auto` here follow the bit-width carve-out in the
project's prefer-`auto` convention.

Verified `-Wall -Wextra -Wconversion` introduces no new warnings and in fact drops
one pre-existing warning at line 212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaQmR3ZYuFBcbrt4mJzjDK