### PR TITLE
[am29000] Add Am29050 CONSTHZ instruction

### DIFF
--- a/src/table_am29000.cpp
+++ b/src/table_am29000.cpp
@@ -300,6 +300,7 @@ static constexpr uint8_t INDEX_AM29000[] PROGMEM = {
 // Instructions found only on the Am29050.  Every other family member reserves
 // these operation codes for instruction emulation.
 constexpr Entry TABLE_AM29050[] PROGMEM = {
+    E2(0x05000000, TEXT_CONSTHZ, M_RA, M_IMH),
     E3(0xAA000000, TEXT_ORN,     M_RC, M_RA, M_RBI),
     X4(0xD8000000, TEXT_FMAC,    M_FUNC, M_ACNH, M_RA, M_RB, EXT_FPU),
     X4(0xD9000000, TEXT_DMAC,    M_FUNC, M_ACNH, M_RA, M_RB, EXT_FPU),
@@ -310,13 +311,14 @@ constexpr Entry TABLE_AM29050[] PROGMEM = {
 };
 
 static constexpr uint8_t INDEX_AM29050[] PROGMEM = {
-      2,  // TEXT_DMAC
-      4,  // TEXT_DMSM
-      1,  // TEXT_FMAC
-      3,  // TEXT_FMSM
-      6,  // TEXT_MFACC
-      5,  // TEXT_MTACC
-      0,  // TEXT_ORN
+      0,  // TEXT_CONSTHZ
+      3,  // TEXT_DMAC
+      5,  // TEXT_DMSM
+      2,  // TEXT_FMAC
+      4,  // TEXT_FMSM
+      7,  // TEXT_MFACC
+      6,  // TEXT_MTACC
+      1,  // TEXT_ORN
 };
 // clang-format on
 

--- a/src/text_am29000.cpp
+++ b/src/text_am29000.cpp
@@ -54,6 +54,7 @@ constexpr char TEXT_CLASS[]   PROGMEM = "CLASS";
 constexpr char TEXT_CLZ[]     PROGMEM = "CLZ";
 constexpr char TEXT_CONST[]   PROGMEM = "CONST";
 constexpr char TEXT_CONSTH[]  PROGMEM = "CONSTH";
+constexpr char TEXT_CONSTHZ[] PROGMEM = "CONSTHZ";
 constexpr char TEXT_CONSTN[]  PROGMEM = "CONSTN";
 constexpr char TEXT_CONVERT[] PROGMEM = "CONVERT";
 constexpr char TEXT_CPBYTE[]  PROGMEM = "CPBYTE";

--- a/src/text_am29000.h
+++ b/src/text_am29000.h
@@ -57,6 +57,7 @@ extern const char TEXT_CLASS[]   PROGMEM;
 extern const char TEXT_CLZ[]     PROGMEM;
 extern const char TEXT_CONST[]   PROGMEM;
 extern const char TEXT_CONSTH[]  PROGMEM;
+extern const char TEXT_CONSTHZ[] PROGMEM;
 extern const char TEXT_CONSTN[]  PROGMEM;
 extern const char TEXT_CONVERT[] PROGMEM;
 extern const char TEXT_CPBYTE[]  PROGMEM;

--- a/test/autogen/Makefile
+++ b/test/autogen/Makefile
@@ -55,10 +55,8 @@ NOASM_targets = i80286 h8s2000n h8s2000 h8s2600n h8s2600 i960
 # h8500: the disassembler emits MOV:F negative displacements as @(-0x7F,FP),
 # which ASL rejects (it needs @((-0x7F),fp)); the curated reference test, which
 # spells them ASL-compatibly, is byte-identical with ASL.
-# am29050: ASL has no AM29050 selector, and knows neither the seven opcodes
-# exclusive to that chip (ORN, FMAC, DMAC, FMSM, DMSM, MTACC, MFACC) nor its
-# own special-purpose registers.  The other five variants map onto the AM29245
-# and AM29240 selectors in their wrappers.
+# am29050: ASL has no AM29050 selector, so it knows neither the opcodes
+# exclusive to that chip nor its own special-purpose registers.
 # i960: ASL's code960.c has six encoding bugs (wrong opcodes for xor, bno and
 # testno, src2 routed into the src/dst field for scanbyte and synmov*, and an
 # integer literal on a register-pair operand evaluated as a float), so it

--- a/test/autogen/gen_am29050.ginc
+++ b/test/autogen/gen_am29050.ginc
@@ -37,6 +37,8 @@
       mtsrim   cfg, 0x0504
       mtsrim   cha, 0x0505
       mtsrim   chd, 0x0506
+      consthz  gr7, 0x06080000
+      consthz  lr0, 0x06810000
       loadl    0, 7, gr8, gr9
       loadl    0, 7, gr8, lr0
       loadl    0, 7, lr0, lr1

--- a/test/autogen/gen_am29050.inc
+++ b/test/autogen/gen_am29050.inc
@@ -37,6 +37,8 @@
       MTSRIM   CFG, 0x0504
       MTSRIM   CHA, 0x0505
       MTSRIM   CHD, 0x0506
+      CONSTHZ  GR7, 0x0608
+      CONSTHZ  LR0, 0x0681
       LOADL    0, 7, GR8, GR9
       LOADL    0, 7, GR8, LR0
       LOADL    0, 7, LR0, LR1
@@ -767,11 +769,11 @@
       SETIP    GR0, LR0, LR1
       SETIP    GR0, LR0, GR0
       INV      0
-      JMP      0x00029000
-      JMPF     LR38, 0x0002A29C
-      JMPF     GR0, 0x0002A008
-      CALL     LR42, 0x0002B2B4
-      CALL     GR0, 0x0002B010
+      JMP      0x00029008
+      JMPF     LR38, 0x0002A2A4
+      JMPF     GR0, 0x0002A010
+      CALL     LR42, 0x0002B2BC
+      CALL     GR0, 0x0002B018
       ORN      LR43, LR44, LR45
       ORN      LR43, LR44, GR0
       ORN      LR43, GR0, GR1
@@ -784,10 +786,10 @@
       ORN      LR44, GR0, 1
       ORN      GR0, GR1, 2
       ORN      GR0, LR0, 0x81
-      JMPT     LR46, 0x0002C2FC
-      JMPT     GR0, 0x0002C048
-      JMPFDEC  LR54, 0x0002E324
-      JMPFDEC  GR0, 0x0002E050
+      JMPT     LR46, 0x0002C304
+      JMPT     GR0, 0x0002C050
+      JMPFDEC  LR54, 0x0002E32C
+      JMPFDEC  GR0, 0x0002E058
       MFTLB    LR55, LR56
       MFTLB    LR55, GR0
       MFTLB    GR0, GR1

--- a/test/test_asm_am29000.cpp
+++ b/test/test_asm_am29000.cpp
@@ -322,6 +322,10 @@ void test_no_coprocessor() {
 }
 
 void test_am29050() {
+    TEST("CONSTHZ gr96, 0x5678", 0x05566078);
+    TEST("CONSTHZ gr0, 0",       0x05000000);
+    // The operand is the 16-bit field itself, so it may not overflow it.
+    ERRT("CONSTHZ gr96, 0x10000", OVERFLOW_RANGE, "0x10000", 0x05006000);
     TEST("ORN   gr96, gr97, gr98", 0xAA606162);
     TEST("ORN   gr96, gr97, 15",   0xAB60610F);
     TEST("FMAC  0, 0, gr97, gr98", 0xD8006162);
@@ -350,6 +354,7 @@ void test_am29050() {
 }
 
 void test_no_am29050() {
+    ERUI("CONSTHZ gr96, 0x5678");
     ERUI("ORN   gr96, gr97, gr98");
     ERUI("FMSM  gr96, gr97, gr98");
     ERUI("MTACC gr97, 1, 0");

--- a/test/test_dis_am29000.cpp
+++ b/test/test_dis_am29000.cpp
@@ -396,6 +396,8 @@ void test_no_coprocessor() {
 }
 
 void test_am29050() {
+    TEST("CONSTHZ", "GR96, 0x5678", 0x05566078);
+    TEST("CONSTHZ", "GR0, 0",       0x05000000);
     TEST("ORN",   "GR96, GR97, GR98", 0xAA606162);
     TEST("ORN",   "GR96, GR97, 15", 0xAB60610F);
     TEST("FMAC",  "0, 0, GR97, GR98", 0xD8006162);
@@ -421,6 +423,7 @@ void test_am29050() {
 }
 
 void test_no_am29050() {
+    UNKN(0x05566078);
     UNKN(0xAA606162);
     UNKN(0xD8006162);
     UNKN(0xD9006162);
@@ -435,7 +438,6 @@ void test_no_am29050() {
 // for instruction emulation.
 void test_illegal() {
     UNKN(0x00000000);
-    UNKN(0x05000000);
     UNKN(0x76000000);
     UNKN(0x77000000);
     UNKN(0x7F000000);


### PR DESCRIPTION
The Am29050 has a fourth constant-generating instruction, CONSTHZ (Constant
High, Zero Lower), which libasm did not implement.

- Operation code 0x05, `CONSTHZ ra, const16`, DEST <- I16 << 16.
- Am29050 only, so it joins ORN in `TABLE_AM29050` as the second entry there
  that is not a floating point instruction. Every other family member reserves
  the operation code for instruction emulation.
- The operand takes the existing `M_IMH` mode of CONSTH: the manual makes it
  the 16-bit field itself, while GNU as takes a 32-bit value and keeps its high
  half, so the `extern-symbol` option applies to it as it does to CONSTH.

Checked against the Am29050 User's Manual page 8-34, and against GNU as, which
encodes `consthz gr96,0x56780000` as 05566078 -- the same bytes libasm now
emits for `CONSTHZ gr96, 0x5678`. ASL has no Am29050 support and no CONSTHZ.

The regenerated gen_am29050 baselines gain the two CONSTHZ forms and lose no
coverage; the other nine lines of the diff are branch targets shifted by the
eight bytes the two new instructions occupy.
