### PR TITLE
[mc68000] Give each CPU the FPU and PMMU it has

### DIFF
--- a/src/table_mc68000.cpp
+++ b/src/table_mc68000.cpp
@@ -2244,8 +2244,17 @@ Error TableMc68000::searchCpuName(StrScanner &name, CpuType &cpuType) const {
 void Config::setCpuType(CpuType cpuType) {
     _cpuSpec.cpu = cpuType;
     ConfigImpl::setCpuType(cpuType);
-    setFpuType(_cpuSpec.fpu == FPU_NONE ? FPU_NONE : FPU_ON);
-    setPmmuType(_cpuSpec.pmmu == PMMU_NONE ? PMMU_NONE : PMMU_ON);
+    // Whatever the CPU has on chip is present: the MC68040 has both a floating
+    // point unit and a PMMU, the MC68030 a PMMU alone.  Earlier parts reach
+    // theirs through a separate MC68881 or MC68851, so those are asked for
+    // with the fpu and pmmu options instead.  The same options turn either off
+    // to name the cut-down MC68040s -- the MC68LC040 has no floating point
+    // unit, the MC68EC040 has neither.
+    //
+    // This cannot be left to reset(), which runs before a CPU is chosen:
+    // PMMU_ON names no PMMU until then and degrades to PMMU_NONE.
+    setFpuType(mc68040() || _cpuSpec.fpu != FPU_NONE ? FPU_ON : FPU_NONE);
+    setPmmuType(mc68030() || mc68040() || _cpuSpec.pmmu != PMMU_NONE ? PMMU_ON : PMMU_NONE);
 }
 
 const /*PROGMEM*/ char *Config::fpu_P() const {


### PR DESCRIPTION
`asm -C mc68040` assembled the PMMU instructions but `dis -C MC68040` could not
read them back without an explicit `--pmmu`, so the two sides disagreed on what
an MC68040 is. The same applied to the MC68030.

The cause is that `reset()` runs before a CPU is chosen. `setPmmuType(PMMU_ON)`
names no PMMU until then -- it only matches the MC68020, MC68030 and MC68040 --
so the disassembler's request degraded to `PMMU_NONE`, and selecting the CPU
afterwards mapped that to the PMMU-less `PMMU_MC68EC040`. The assembler only
appeared to work by accident: `setCpuType` tested `pmmu == PMMU_NONE ? NONE :
ON`, and `PMMU_MC68EC040` is not `PMMU_NONE`, so a later CPU selection silently
promoted the EC part to a full PMMU.

Each CPU now gets what it has on chip -- both units on the MC68040, a PMMU on
the MC68030 -- while anything already asked for is preserved, so the MC68020's
separate MC68881 and MC68851 stay opt-in through the fpu and pmmu options. The
same options turn either unit off to name the cut-down parts: `--fpu=none` is
an MC68LC040, `--fpu=none --pmmu=none` an MC68EC040.

Note the floating point unit had the same asymmetry, which is worth recording
because it is easy to read the other way round: `asm -C mc68040` rejected
`fadd.x` while `dis -C MC68040` decoded it. `FPU_ON` resolves to an MC68881 for
any CPU, so unlike `PMMU_ON` it survived `reset()` and left the disassembler
decoding floating point on every CPU. That behaviour is kept -- only the
MC68040's assembler side changes -- because taking it away would drop 3588
F-line instructions from each of the generated tests.

Regenerating the whole mc68000 family gives byte-identical baselines, which
also says the committed ones were produced with these units on and it was the
code that had drifted.
